### PR TITLE
Use explicit utf-16le-bom

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,4 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto
-*.inf text working-tree-encoding=UTF-16
+*.inf text working-tree-encoding=UTF-16LE-BOM


### PR DESCRIPTION
UTF-16 worked ok until repository refresh, then the INF files were
rewritten as UTF-16BE-BOM, which doesn't work. Explicitly request
UTF-16LE-BOM.