### PR TITLE
bcmemmc2: Change NTarm64 to NT$ARCH$

### DIFF
--- a/drivers/sd/bcm2711/bcmemmc2/bcmemmc2.inx
+++ b/drivers/sd/bcm2711/bcmemmc2/bcmemmc2.inx
@@ -30,7 +30,7 @@ PnpLockdown = 1
 [Manufacturer]
 %Broadcom% = Broadcom, NT$ARCH$
 
-[Broadcom.NTarm64]
+[Broadcom.NT$ARCH$]
 %ACPI\BRCME88C.DeviceDesc% = SDHostEMMC2, ACPI\BRCME88C
 
 ; ///////////////////////////////////////////////////////////


### PR DESCRIPTION
CI indicates that InfVerif is throwing build errors.

d:\a\windows-drivers\windows-drivers\drivers\sd\bcm2711\bcmemmc2\bcmemmc2.inx
: error 1203: Section [broadcom.ntarm] not found.
[D:\a\windows-drivers\windows-drivers\drivers\sd\bcm2711\bcmemmc2\bcmemmc2.vcxproj]

Change the section naming to NT$ARCH$

Signed-off-by: Christopher Co <35273088+christopherco@users.noreply.github.com>