### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,31 @@
-Raspberry Pi Board Support Package for Windows 10 IoT Core
+Raspberry Pi Board Support Package for Windows 10
 ==============
 
-## Welcome to the Raspberry Pi Board Support Package (BSP) for Windows 10 IoT Core
+## Welcome to the Raspberry Pi Board Support Package (BSP) for Windows 10
 
-This repository contains BSP components for the Raspberry Pi 2, 3, and Compute Module. This BSP repository is under community support; it is functional with the Fall 2018 release of Windows 10 IoT Core but is not actively maintained by Microsoft. BSP elements included in this repository may contain features that are not available with Windows 10 IoT Core releases.
+This repository contains BSP components for the Raspberry Pi 2, 3 and Compute Modules running 32-bit Windows 10 IoT Core (version 1809).
+It also contains BSP components for the Raspberry Pi 2 (v1.2), 3, 4 and corresponding Compute Modules running 64-bit Windows 10.
 
-For more information about Windows 10 IoT Core, see online documentation [here](http://windowsondevices.com)
+This BSP repository is under community support; it is not actively maintained by Microsoft. 
+For Raspberry Pi 4 onwards, it's designed for use with Windows 10 version 2004 and later, because of use of newer driver frameworks which are not available on earlier releases.
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-## Firmware binaries
+## 32-bit firmware
 
 Sample binaries of the firmware is included in [RPi.BootFirmware](bspfiles/Packages/RPi.BootFirmware) to enable quick prototyping. The sources for these binaries are listed below.
 
 1. Firmware binaries : [RaspberryPi/Firmware](https://github.com/raspberrypi/firmware)
 2. UEFI Sources : [RPi/UEFI](https://github.com/ms-iot/RPi-UEFI)
 
-### UEFI Customisations
+## 64-bit firmware
+
+For the Raspberry Pi 4, firmware from the [Pi Firmware Task Force](https://rpi4-uefi.dev) is used, which provides UEFI and ACPI support.
+For the Raspberry Pi 2 (v1.2) and Raspberry Pi 3, the Pi Firmware Task Force provides firmware at https://github.com/pftf/RPi3/releases, which provides UEFI and ACPI support.
+
+### 32-bit EFI Customisations
+
+Note: this section is only applicable to 32-bit Windows 10 IoT Core on Raspberry Pi 3 and earlier.
 
 [SMBIOS requirements of Windows 10 IoT Core OEM Licensing](https://docs.microsoft.com/en-us/windows-hardware/manufacture/iot/license-requirements#smbios-support) requires a custom version of kernel.img file with the proper SMBIOS values.
 
@@ -24,15 +33,17 @@ See [PlatformSmbiosDxe.c](https://github.com/ms-iot/RPi-UEFI/blob/ms-iot/Pi3Boar
 
 ## Build the drivers
 
-1. Clone https://github.com/ms-iot/rpi-iotcore
+1. Clone https://github.com/raspberrypi/windows-drivers
 1. Open Visual Studio with Administrator privileges
-1. In Visual Studio: File -> Open -> Project/Solution -> Select `rpi-iotcore\build\bcm2836\buildbcm2836.sln`
+1. In Visual Studio: File -> Open -> Project/Solution -> Select `windows-drivers\build\bcm2836\buildbcm2836.sln`
 1. Set your build configuration (Release or Debug)
 1. Build -> Build Solution
 
-The resulting driver binaries will be located in the `rpi-iotcore\build\bcm2836\ARM` folder.
+The resulting driver binaries will be located in the `windows-drivers\build\bcm2836\ARM` folder, or `windows-drivers\build\bcm2836\ARM64` if you picked an Arm 64-bit configuration.
 
 ## Export the bsp
+
+Note: this section is only applicable to Windows 10 IoT Core.
 
 We provide a `binexport.ps1` script to scrape the BSP components together into a zip file for easy use with the IoT ADK AddonKit.
 1. Open Powershell

--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ It also contains BSP components for the Raspberry Pi 2 (v1.2), 3, 4 and correspo
 This BSP repository is under community support; it is not actively maintained by Microsoft. 
 For Raspberry Pi 4 onwards, it's designed for use with Windows 10 version 2004 and later, because of use of newer driver frameworks which are not available on earlier releases.
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+## 64-bit firmware
+
+For the Raspberry Pi 4, firmware from the [Pi Firmware Task Force](https://rpi4-uefi.dev) is used, which provides UEFI and ACPI support. It is available at https://github.com/pftf/RPi4/releases.
+
+For the Raspberry Pi 2 (v1.2) and Raspberry Pi 3, the Pi Firmware Task Force provides firmware at https://github.com/pftf/RPi3/releases, which provides UEFI and ACPI support.
 
 ## 32-bit firmware
 
@@ -17,11 +21,6 @@ Sample binaries of the firmware is included in [RPi.BootFirmware](bspfiles/Packa
 
 1. Firmware binaries : [RaspberryPi/Firmware](https://github.com/raspberrypi/firmware)
 2. UEFI Sources : [RPi/UEFI](https://github.com/ms-iot/RPi-UEFI)
-
-## 64-bit firmware
-
-For the Raspberry Pi 4, firmware from the [Pi Firmware Task Force](https://rpi4-uefi.dev) is used, which provides UEFI and ACPI support.
-For the Raspberry Pi 2 (v1.2) and Raspberry Pi 3, the Pi Firmware Task Force provides firmware at https://github.com/pftf/RPi3/releases, which provides UEFI and ACPI support.
 
 ### 32-bit EFI Customisations
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ See [PlatformSmbiosDxe.c](https://github.com/ms-iot/RPi-UEFI/blob/ms-iot/Pi3Boar
 1. Set your build configuration (Release or Debug)
 1. Build -> Build Solution
 
-The resulting driver binaries will be located in the `windows-drivers\build\bcm2836\ARM` folder, or `windows-drivers\build\bcm2836\ARM64` if you picked an Arm 64-bit configuration.
+The resulting driver binaries will be located in the `windows-drivers\build\bcm2836\ARM\Output` folder, or `windows-drivers\build\bcm2836\ARM64\Output` if you picked an Arm 64-bit configuration.
 
 ## Export the bsp
 


### PR DESCRIPTION
Windows 10 IoT Core is out of support since November 2020. (see https://docs.microsoft.com/en-us/lifecycle/products/windows-10-iot-core)

By having the Broadcom GENET Ethernet driver built with the NetAdapterCx driver framework, which is only available on Windows 10 version 2004 onwards, this repository is not compilable as a whole for earlier releases. The last release of Windows 10 IoT Core to exist is version 1809.

Should the CoC section remain as it's no longer under the Microsoft umbrella but on the Raspberry Pi org?