### PR TITLE
bcm2836sdhc - fix early interrupts

### DIFF
--- a/drivers/sd/bcm2836/bcm2836sdhc/bcm2836sdhc.c
+++ b/drivers/sd/bcm2836/bcm2836sdhc/bcm2836sdhc.c
@@ -455,7 +455,9 @@ SdhcSlotInitialize (
     SdhcExtension->OutstandingRequest = NULL;
 
     //
-    // Disable interrupts until we're ready to handle them.
+    // Disable interrupts until we're ready to handle them. No need to have
+    // them enabled yet, and some versions of sdport.sys crash if any
+    // interrupts come at this point.
     //
 
     SdhcWriteRegisterUlong(SdhcExtension,

--- a/drivers/sd/bcm2836/bcm2836sdhc/bcm2836sdhc.c
+++ b/drivers/sd/bcm2836/bcm2836sdhc/bcm2836sdhc.c
@@ -455,11 +455,7 @@ SdhcSlotInitialize (
     SdhcExtension->OutstandingRequest = NULL;
 
     //
-    // Enable all interrupt signals from controller to the OS,
-    // but mask all.
-    // Means we are only using SDHC_INTERRUPT_ERROR_STATUS_ENABLE to
-    // control interrupts, this way disabled events do not get reflected
-    // in the status register.
+    // Disable interrupts until we're ready to handle them.
     //
 
     SdhcWriteRegisterUlong(SdhcExtension,
@@ -467,7 +463,7 @@ SdhcSlotInitialize (
                            0);
     SdhcWriteRegisterUlong(SdhcExtension,
                            SDHC_INTERRUPT_ERROR_SIGNAL_ENABLE,
-                           SDHC_ALL_EVENTS);
+                           0);
 
     return STATUS_SUCCESS;
 } // SdhcSlotInitialize (...)


### PR DESCRIPTION
The Arasan driver enables interrupts during SlotInitialize, but sdport
isn't ready for interrupts at that point. This works ok as long as no
interrupts fire right away, but if any interrupts fire before sdport is
ready, it causes various problems.

If bcm2836sdhc is the only driver using the given IRQ, and it is only
loaded during boot, things seem to work most of the time.

If bcm2836sdhc is sharing an IRQ with another active device or if you
load the driver after the system has been running a while, it often
crashes or hangs.

Fix this by disabling interrupts during SlotInitialize. sdport will
enable interrupts when it is ready for them by calling ToggleInterrupts.

Note that this can be considered a bug in sdport - it should be ready
for interrupts before it connects the interrupt. I've provided this
feedback to the sdport owners. Fixing the driver works around the issue.

Note that there is still a crash if you load both bcm2836sdhc and
SDHostBRCME88C and then unload one of them. I don't know the root cause
of this. It may be a bug in sdport.sys.