### PR TITLE
SDHostBRCME88C - sdport-based driver for RPI4 emmc2

### DIFF
--- a/build/bcm2836/buildbcm2836.sln
+++ b/build/bcm2836/buildbcm2836.sln
@@ -58,6 +58,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "rpiuxflt", "..\..\drivers\u
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "bcmgenet", "..\..\drivers\net\bcm2711\bcmgenet\bcmgenet.vcxproj", "{14481F54-B4E3-451C-BBE1-DEA167DA623C}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SDHostBRCME88C", "..\..\drivers\sd\bcm2711\brcme88c\SDHostBRCME88C.vcxproj", "{DC75D1FD-24D8-462B-8566-5E672802DDF3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM = Debug|ARM
@@ -226,6 +228,18 @@ Global
 		{14481F54-B4E3-451C-BBE1-DEA167DA623C}.Release|ARM.Build.0 = Release|ARM
 		{14481F54-B4E3-451C-BBE1-DEA167DA623C}.Release|ARM64.ActiveCfg = Release|ARM64
 		{14481F54-B4E3-451C-BBE1-DEA167DA623C}.Release|ARM64.Build.0 = Release|ARM64
+		{DC75D1FD-24D8-462B-8566-5E672802DDF3}.Debug|ARM.ActiveCfg = Debug|ARM
+		{DC75D1FD-24D8-462B-8566-5E672802DDF3}.Debug|ARM.Build.0 = Debug|ARM
+		{DC75D1FD-24D8-462B-8566-5E672802DDF3}.Debug|ARM.Deploy.0 = Debug|ARM
+		{DC75D1FD-24D8-462B-8566-5E672802DDF3}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{DC75D1FD-24D8-462B-8566-5E672802DDF3}.Debug|ARM64.Build.0 = Debug|ARM64
+		{DC75D1FD-24D8-462B-8566-5E672802DDF3}.Debug|ARM64.Deploy.0 = Debug|ARM64
+		{DC75D1FD-24D8-462B-8566-5E672802DDF3}.Release|ARM.ActiveCfg = Release|ARM
+		{DC75D1FD-24D8-462B-8566-5E672802DDF3}.Release|ARM.Build.0 = Release|ARM
+		{DC75D1FD-24D8-462B-8566-5E672802DDF3}.Release|ARM.Deploy.0 = Release|ARM
+		{DC75D1FD-24D8-462B-8566-5E672802DDF3}.Release|ARM64.ActiveCfg = Release|ARM64
+		{DC75D1FD-24D8-462B-8566-5E672802DDF3}.Release|ARM64.Build.0 = Release|ARM64
+		{DC75D1FD-24D8-462B-8566-5E672802DDF3}.Release|ARM64.Deploy.0 = Release|ARM64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/drivers/sd/bcm2711/README.md
+++ b/drivers/sd/bcm2711/README.md
@@ -30,7 +30,7 @@ There are two drivers available for the **EMMC2** controller.
     because it can use DMA and can use 50 MB/s transfer speeds.
   - Disadvantage: `SDHostBRCME88C.sys` is probably less reliable than
     `sdbus.sys`. `SDHostBRCME88C.sys` is new and not yet fully tested, plus
-    `sdbus.sys` is not as well maintained by Microsoft and has some known
+    `sdport.sys` is not as well-maintained by Microsoft and has some known
     issues.
 
 For now, most users will probably want to use the `bcm2711\bcmemmc2` driver

--- a/drivers/sd/bcm2711/README.md
+++ b/drivers/sd/bcm2711/README.md
@@ -1,0 +1,37 @@
+# SD Host drivers for Raspberry Pi 4
+
+The Raspberry Pi 4 contains 3 SD Host controllers. The "BCM2711 ARM Peripherals"
+datasheet calls them **SDHOST**, **EMMC**, and **EMMC2**.
+
+- **SDHOST** - old, unusual design, uses `bcm2836\rpisdhc` driver (an sdport.sys
+  miniport driver). The RPi4 UEFI does not currently expose this device. In
+  theory it could be enabled and connected to GPIO pins to run an external SD
+  slot.
+- **EMMC** - newer controller, supports SD memory and SDIO, uses
+  `bcm2836\bcm2836sdhc` driver (an sdport.sys miniport driver). UEFI currently
+  exposes this as `ACPI\ARASAN` and connects it to the WiFi SDIO card by
+  default.
+- **EMMC2** - new for RPi4, supports only SD memory. UEFI currently exposes this
+  as `ACPI\BRCME88C` and connects it to the Micro-SD slot by default.
+
+There are two drivers available for the **EMMC2** controller.
+
+- `bcm2711\bcmemmc2` contains configuration files that load the Windows in-box
+  `sdbus.sys` driver to run the EMMC2 controller.
+  - Advantage: `sdbus.sys` is stable and reliable.
+  - Disadvantage: `sdbus.sys` uses more CPU for slower data transfers because it
+    can only use PIO (cannot use EMMC2's nonstandard DMA) and can only use 25
+    MB/s transfer speeds (cannot switch the Raspberry Pi's voltage regulator to
+    the 1.8v needed for UHS signaling).
+- `bcm2711\brcme88c` contains the `SDHostBRCME88C.sys` miniport driver that
+  works with the Windows in-box `sdport.sys` port driver to run the EMMC2
+  controller.
+  - Advantage: `SDHostBRCME88C.sys` uses less CPU for faster data transfers
+    because it can use DMA and can use 50 MB/s transfer speeds.
+  - Disadvantage: `SDHostBRCME88C.sys` is probably less reliable than
+    `sdbus.sys`. `SDHostBRCME88C.sys` is new and not yet fully tested, plus
+    `sdbus.sys` is not as well maintained by Microsoft and has some known
+    issues.
+
+For now, most users will probably want to use the `bcm2711\bcmemmc2` driver
+while work continues on testing/improving the `bcm2711\brcme88c` driver.

--- a/drivers/sd/bcm2711/brcme88c/AutoLogger.reg
+++ b/drivers/sd/bcm2711/brcme88c/AutoLogger.reg
@@ -1,0 +1,14 @@
+﻿Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Control\WMI\Autologger\SDHostBRCME88C]
+"Guid"="{62a2a14c-5448-4eca-b293-fe05f5eb89fc}"
+"BufferSize"=dword:00000040
+"LogFileMode"=dword:00080001
+"Status"=dword:00000000
+"Start"=dword:00000001
+
+[HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Control\WMI\Autologger\SDHostBRCME88C\{f2782ab9-d1a5-5f95-240a-ac933a6937e2}]
+"Enabled"=dword:00000001
+"EnableLevel"=dword:00000004
+"EnableFlags"=dword:00000001
+"Status"=dword:00000000

--- a/drivers/sd/bcm2711/brcme88c/README.md
+++ b/drivers/sd/bcm2711/brcme88c/README.md
@@ -9,12 +9,21 @@ Implemented using the
 [Microsoft SDHC driver sample](https://github.com/microsoft/Windows-driver-samples/tree/master/sd/miniport/sdhc)
 as a reference.
 
-## TODO
+## NOTES
 
 - If both bcm2836sdhc and this driver are loaded and one is unloaded, the
   system will eventually crash. Appears to be a bug in sdport.sys's interrupt
   handling (the Arasan and eMMC2 controllers share an interrupt vector).
-- Regulator voltage cannot be controlled while in crashdump mode.
-- Tuning? (required to support UHS-SDR50, but I'm not sure if that's useful)
-- Testing - make sure the DMA never corrupts data, test in crashdump mode.
+  - Possible workaround: Don't use both bcm2836sdhc and this driver.
+  - Possible workaround: Don't unload drivers.
+
+## TODO
+
+- Regulator voltage cannot be controlled while in crashdump mode. Possible fix
+  would be to have mailbox support via ACPI method instead of via RPIQ driver.
+- Does not support UHS-SDR50 because we don't support tuning.
+  - Would be easy to implement, but I'm not sure SDR50 is needed.
+- Could use some performance testing to determine which transfers should use
+  PIO and which transfers should use DMA.
+- Needs testing in various scenarios, e.g. crashdump mode.
 - Figure out how to get this driver into SafeOS for Windows Update.

--- a/drivers/sd/bcm2711/brcme88c/README.md
+++ b/drivers/sd/bcm2711/brcme88c/README.md
@@ -1,0 +1,19 @@
+# Broadcom SD Host (BRCME88C) for Raspberry Pi 4
+
+Driver for the eMMC2 host controller (BRCME88C) for Raspberry Pi 4.
+
+This is a miniport - it depends on the in-box sdport.sys to handle the
+SD/SDIO/eMMC protocol and WDM interfaces.
+
+Implemented using the
+[Microsoft SDHC driver sample](https://github.com/microsoft/Windows-driver-samples/tree/master/sd/miniport/sdhc)
+as a reference.
+
+## TODO
+
+- Regulator voltage should be set to 3.3v during ResetHw, but that leads to
+  deadlock with current RPIQ driver. This means the driver will be incompatible
+  with some SD cards that are UHS-capabile but not LV-compliant.
+- DMA. (via a bounce buffer)
+- Driver crashes if unloaded. Appears to be a bug in sdport.sys.
+- Tuning? (required to support UHS-SDR50)

--- a/drivers/sd/bcm2711/brcme88c/README.md
+++ b/drivers/sd/bcm2711/brcme88c/README.md
@@ -11,9 +11,10 @@ as a reference.
 
 ## TODO
 
-- Regulator voltage should be set to 3.3v during ResetHw, but that leads to
-  deadlock with current RPIQ driver. This means the driver will be incompatible
-  with some SD cards that are UHS-capabile but not LV-compliant.
-- DMA. (via a bounce buffer)
-- Driver crashes if unloaded. Appears to be a bug in sdport.sys.
-- Tuning? (required to support UHS-SDR50)
+- If both bcm2836sdhc and this driver are loaded and one is unloaded, the
+  system will eventually crash. Appears to be a bug in sdport.sys's interrupt
+  handling (the Arasan and eMMC2 controllers share an interrupt vector).
+- Regulator voltage cannot be controlled while in crashdump mode.
+- Tuning? (required to support UHS-SDR50, but I'm not sure if that's useful)
+- Testing - make sure the DMA never corrupts data, test in crashdump mode.
+- Figure out how to get this driver into SafeOS for Windows Update.

--- a/drivers/sd/bcm2711/brcme88c/SDHostBRCME88C.inx
+++ b/drivers/sd/bcm2711/brcme88c/SDHostBRCME88C.inx
@@ -3,7 +3,6 @@ Signature="$Windows NT$"
 Class=SDHost
 ClassGUID={a0a588a4-c46f-4b37-b7ea-c82fe89870c6}
 Provider=%ProviderString%
-DriverVer=04/02/2015,10.0.10053
 CatalogFile=SDHostBRCME88C.cat
 PnpLockdown=1
 

--- a/drivers/sd/bcm2711/brcme88c/SDHostBRCME88C.inx
+++ b/drivers/sd/bcm2711/brcme88c/SDHostBRCME88C.inx
@@ -1,0 +1,82 @@
+[Version]
+Signature="$Windows NT$"
+Class=SDHost
+ClassGUID={a0a588a4-c46f-4b37-b7ea-c82fe89870c6}
+Provider=%ProviderString%
+DriverVer=04/02/2015,10.0.10053
+CatalogFile=SDHostBRCME88C.cat
+PnpLockdown=1
+
+[SourceDisksNames]
+1 = Disk
+
+[SourceDisksFiles]
+SDHostBRCME88C.sys = 1
+
+[Manufacturer]
+%RPI%=RPI,NT$ARCH$
+
+[ControlFlags]
+BasicDriverOk=*
+ExcludeFromSelect=*
+
+[RPI.NT$ARCH$]
+%ACPI\BRCME88C.DeviceDesc%=SDHostBRCME88C, ACPI\BRCME88C
+
+[SDHostBRCME88C]
+CopyFiles=SDHostBRCME88C_CopyFiles
+AddReg=SDHostBRCME88C_Reg
+
+[SDHostBRCME88C_CopyFiles]
+SDHostBRCME88C.sys
+
+[DestinationDirs]
+SDHostBRCME88C_CopyFiles=12
+
+[SDHostBRCME88C.HW]
+AddReg=SDHostBRCME88C_LocationReg
+
+[SDHostBRCME88C.Services]
+AddService = SDHostBRCME88C, 2, SDHostBRCME88C_ServiceInst
+
+; Service install
+[SDHostBRCME88C_ServiceInst]
+ServiceType    = 1 ; SERVICE_KERNEL_DRIVER
+StartType      = 3 ; SERVICE_DEMAND_START
+ErrorControl   = 1 ; SERVICE_ERROR_NORMAL
+ServiceBinary  = %12%\SDHostBRCME88C.sys
+LoadOrderGroup = System Bus Extender
+AddReg         = SDHostBRCME88C_ServiceReg
+
+; Registry keys
+
+[SDHostBRCME88C_Reg]
+HKR,,Driver,,"SDHostBRCME88C.sys"
+
+[SDHostBRCME88C_LocationReg]
+HKR,,UINumberDescFormat,,%SDHostBRCME88C_Slot%
+
+[SDHostBRCME88C_ServiceReg]
+HKR,,BootFlags,0x00010003,0x00000008 ; CM_SERVICE_SD_DISK_BOOT_LOAD
+HKR,Parameters,SdCmdFlags,1,    05,01, 06,01, 08,11, 09,19, 0A,19, 0D,11, \
+                                10,01, 11,01, 12,01, 17,01, 18,05, 19,05, \
+                                1A,01, 1B,01, 1C,01, \
+                                20,05, 21,05, 26,05, \
+                                2A,01, \
+                                34,02, 35,02, \
+                                37,01, 38,01, \
+                                22,01, 23,05, 24,01, 25,01
+
+HKR,Parameters,SdAppCmdFlags,1, 06,01, 0D,01, 16,01, 17,01, 33,01, \
+                                12,01, 19,01, 1A,01, 26,01, 2B,01, \
+                                2C,01, 2D,01, 2E,01, 2F,01, 30,01, 31,01
+
+[Strings]
+
+; Manufacturer
+RPI="Raspberry Pi"
+
+ACPI\BRCME88C.DeviceDesc="Broadcom SD Host (BRCME88C) for Raspberry Pi 4"
+SDHostBRCME88C_Slot="SD Host Slot %1!u!"
+
+ProviderString="WoR project"

--- a/drivers/sd/bcm2711/brcme88c/SDHostBRCME88C.rc
+++ b/drivers/sd/bcm2711/brcme88c/SDHostBRCME88C.rc
@@ -1,0 +1,11 @@
+#include <windows.h>
+
+#include <ntverp.h>
+
+#define VER_FILETYPE    VFT_DRV
+#define VER_FILESUBTYPE VFT2_DRV_SYSTEM
+#define VER_FILEDESCRIPTION_STR     "Broadcom SD Host (BRCME88C) for Raspberry Pi 4"
+#define VER_INTERNALNAME_STR        "SDHostBRCME88C.sys"
+#define VER_ORIGINALFILENAME_STR    "SDHostBRCME88C.sys"
+
+#include "common.ver"

--- a/drivers/sd/bcm2711/brcme88c/SDHostBRCME88C.vcxproj
+++ b/drivers/sd/bcm2711/brcme88c/SDHostBRCME88C.vcxproj
@@ -57,12 +57,10 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
     <ApiValidator_ModuleWhiteListFile>..\..\sdportwhitelist.xml</ApiValidator_ModuleWhiteListFile>
-    <EnableInf2cat>true</EnableInf2cat>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
     <ApiValidator_ModuleWhiteListFile>..\..\sdportwhitelist.xml</ApiValidator_ModuleWhiteListFile>
-    <EnableInf2cat>true</EnableInf2cat>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>

--- a/drivers/sd/bcm2711/brcme88c/SDHostBRCME88C.vcxproj
+++ b/drivers/sd/bcm2711/brcme88c/SDHostBRCME88C.vcxproj
@@ -1,0 +1,164 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM">
+      <Configuration>Release</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="PropertySheets">
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <ConfigurationType>Driver</ConfigurationType>
+    <DriverType>WDM</DriverType>
+    <TARGETNAME>$(MSBuildProjectName)</TARGETNAME>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <Platform Condition="'$(Platform)' == ''">ARM64</Platform>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{DC75D1FD-24D8-462B-8566-5E672802DDF3}</ProjectGuid>
+    <RootNamespace>$(MSBuildProjectName)</RootNamespace>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(SolutionDir)\..\bsp.props" />
+  </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+    <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <ApiValidator_ModuleWhiteListFile>..\..\sdportwhitelist.xml</ApiValidator_ModuleWhiteListFile>
+    <EnableInf2cat>true</EnableInf2cat>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+    <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <ApiValidator_ModuleWhiteListFile>..\..\sdportwhitelist.xml</ApiValidator_ModuleWhiteListFile>
+    <EnableInf2cat>true</EnableInf2cat>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <ApiValidator_ModuleWhiteListFile>..\..\sdportwhitelist.xml</ApiValidator_ModuleWhiteListFile>
+    <EnableInf2cat>true</EnableInf2cat>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <ApiValidator_ModuleWhiteListFile>..\..\sdportwhitelist.xml</ApiValidator_ModuleWhiteListFile>
+    <EnableInf2cat>true</EnableInf2cat>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+    <Link>
+      <AdditionalDependencies>$(DDK_LIB_PATH)sdport.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <ClCompile />
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile>
+      <PrecompiledHeaderFile>precomp.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>$(IntDir);../../../mailbox/bcm2836;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+    <Link>
+      <AdditionalDependencies>$(DDK_LIB_PATH)sdport.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <ClCompile />
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile>
+      <PrecompiledHeaderFile>precomp.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>$(IntDir);../../../mailbox/bcm2836;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <Link>
+      <AdditionalDependencies>$(DDK_LIB_PATH)sdport.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <ClCompile />
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile>
+      <PrecompiledHeaderFile>precomp.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>$(IntDir);../../../mailbox/bcm2836;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <Link>
+      <AdditionalDependencies>$(DDK_LIB_PATH)sdport.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <ClCompile />
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile>
+      <PrecompiledHeaderFile>precomp.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>$(IntDir);../../../mailbox/bcm2836;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <BuildMacro Include="SDK_INC_PATH">
+      <Value>$(KIT_SHARED_INC_PATH)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+  </ItemGroup>
+  <ItemGroup>
+    <FilesToPackage Include="$(TargetPath)" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="driver.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="SlotExtension.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="driver.h" />
+    <ClInclude Include="SdRegisters.h" />
+    <ClInclude Include="SlotExtension.h" />
+    <ClInclude Include="trace.h" />
+    <ClInclude Include="precomp.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="SDHostBRCME88C.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <Inf Include="SDHostBRCME88C.inx" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/drivers/sd/bcm2711/brcme88c/SdRegisters.h
+++ b/drivers/sd/bcm2711/brcme88c/SdRegisters.h
@@ -90,6 +90,18 @@ enum SdRegCommandType : UCHAR
     SdRegCommandTypeAbort,
 };
 
+enum SdRegDmaAction : unsigned
+{
+    SdRegDmaActionAdma2Nop = 0,
+    SdRegDmaActionAdma2Rsv = 2,
+    SdRegDmaActionAdma2Tran = 4,
+    SdRegDmaActionAdma2Link = 6,
+    SdRegDmaActionAdma3CmdSD = 1,
+    SdRegDmaActionAdma3CmdUHS2 = 3,
+    SdRegDmaActionAdma3Reserved = 5,
+    SdRegDmaActionAdma3IntegratedDescriptor = 7,
+};
+
 union SdRegPowerControl
 {
     explicit constexpr
@@ -432,7 +444,8 @@ struct SdRegisters
     UINT8 AdmaErrorStatus;              // 54
     UINT8 Reserved55;                   // 55
     UINT16 Reserved56;                  // 56
-    UINT64 AdmaSystemAddress;           // 58
+    ULONG AdmaSystemAddress;            // 58
+    ULONG AdmaSystemAddressHigh;        // 5C
     UINT16 PresetValue16s[8];           // 60
     ULONG Reserved70[32];               // 70 - ADMA3, UHS-II, vendor-specific stuff.
     ULONG ReservedF0[3];                // F0
@@ -441,3 +454,21 @@ struct SdRegisters
     UINT8 VendorVersion;                // FF
 };
 static_assert(sizeof(SdRegisters) == 0x100, "SdRegisters");
+
+// Descriptor for 32-bit addresses.
+union SdRegDma32
+{
+    UINT64 U64;
+    ULONG U32s[2];
+    struct
+    {
+        unsigned Valid : 1;
+        unsigned End : 1;
+        unsigned Int : 1;
+        SdRegDmaAction Action : 3;
+        unsigned LengthHigh : 10; // ADMA3
+        unsigned Length : 16;
+        UINT32 Address;
+    };
+};
+static_assert(sizeof(SdRegDma32) == 8, "SdRegDma32");

--- a/drivers/sd/bcm2711/brcme88c/SdRegisters.h
+++ b/drivers/sd/bcm2711/brcme88c/SdRegisters.h
@@ -22,6 +22,9 @@ SOFTWARE.
 
 #pragma once
 
+// Based on PartA2_SD Host_Controller_Simplified_Specification_Ver4.20.pdf
+// from https://www.sdcard.org/downloads/pls/pdf/
+
 enum SdRegSpecVersion : UINT8
 {
     SdRegSpecVersion1 = 0,

--- a/drivers/sd/bcm2711/brcme88c/SdRegisters.h
+++ b/drivers/sd/bcm2711/brcme88c/SdRegisters.h
@@ -1,0 +1,443 @@
+/*
+Copyright 2021 Douglas Cook
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#pragma once
+
+enum SdRegSpecVersion : UINT8
+{
+    SdRegSpecVersion1 = 0,
+    SdRegSpecVersion2 = 1,
+    SdRegSpecVersion3 = 2,
+    SdRegSpecVersion4_0 = 3,
+    SdRegSpecVersion4_1 = 4,
+    SdRegSpecVersion4_2 = 5,
+};
+
+enum SdRegDma : UCHAR
+{
+    SdRegDmaSdma,
+    SdRegDmaReserved,
+    SdRegDma32BitAdma2,
+    SdRegDma64BitAdma2,
+};
+
+enum SdRegVoltage : UCHAR
+{
+    SdRegVoltageNone = 0,
+    SdRegVoltage1_2 = 4,
+    SdRegVoltage1_8 = 5,
+    SdRegVoltage3_0 = 6,
+    SdRegVoltage3_3 = 7,
+};
+
+enum SdRegUhs : UCHAR
+{
+    SdRegUhsSDR12,
+    SdRegUhsSDR25,
+    SdRegUhsSDR50,
+    SdRegUhsSDR104,
+    SdRegUhsDDR50,
+};
+
+enum SdRegDriverStrength : UCHAR
+{
+    SdRegDriverStrengthB,
+    SdRegDriverStrengthA,
+    SdRegDriverStrengthC,
+    SdRegDriverStrengthD,
+};
+
+enum SdRegAutoCmd : UCHAR
+{
+    SdRegAutoCmdDisabled,
+    SdRegAutoCmd12Enable,
+    SdRegAutoCmd32Enable,
+    SdRegAutoCmdAutoSelect,
+};
+
+enum SdRegResponse : UCHAR
+{
+    SdRegResponseNone,
+    SdRegResponse136,
+    SdRegResponse48,
+    SdRegResponse48CheckBusy,
+};
+
+enum SdRegCommandType : UCHAR
+{
+    SdRegCommandTypeNormal,
+    SdRegCommandTypeSuspend,
+    SdRegCommandTypeResume,
+    SdRegCommandTypeAbort,
+};
+
+union SdRegPowerControl
+{
+    explicit constexpr
+    SdRegPowerControl(UINT8 u8)
+        : U8(u8) {}
+
+    UINT8 U8;
+    struct
+    {
+        UCHAR Vdd1Power : 1;
+        SdRegVoltage Vdd1Voltage : 3;
+        UCHAR Vdd2Power : 1;
+        SdRegVoltage Vdd2Voltage : 3;
+    };
+};
+static_assert(sizeof(SdRegPowerControl) == 1, "SdRegPowerControl");
+
+union SdRegCapabilities
+{
+    explicit constexpr
+    SdRegCapabilities(UINT32 low, UINT32 high)
+        : U64(low | ((UINT64)high << 32)) {}
+
+    UINT64 U64;
+    ULONG U32s[2];
+    struct
+    {
+        UCHAR TimeoutClockFrequency : 6;
+        UCHAR Reserved6 : 1;
+        UCHAR TimeoutClockUnit : 1;
+
+        UCHAR BaseFrequencyForSdClock : 8;
+
+        UCHAR MaxBlockLength : 2;
+        UCHAR DeviceBus8Bit : 1;
+        UCHAR Adma2 : 1;
+        UCHAR Reserved20 : 1;
+        UCHAR HighSpeed : 1;
+        UCHAR Sdma : 1;
+        UCHAR SuspendResume : 1;
+
+        UCHAR Voltage3_3 : 1;
+        UCHAR Voltage3_0 : 1;
+        UCHAR Voltage1_8 : 1;
+        UCHAR SystemAddress64BitV4 : 1;
+        UCHAR SystemAddress64BitV3 : 1;
+        UCHAR AsynchronousInterrupt : 1;
+        UCHAR SlotType : 2;
+
+        UCHAR SDR50 : 1;
+        UCHAR SDR104 : 1;
+        UCHAR DDR50 : 1;
+        UCHAR UHS2 : 1;
+        UCHAR DriverTypeA : 1;
+        UCHAR DriverTypeC : 1;
+        UCHAR DriverTypeD : 1;
+        UCHAR Reserved39 : 1;
+
+        UCHAR TimerCountForReTuning : 4;
+        UCHAR Reserved44 : 1;
+        UCHAR UseTuningForSDR50 : 1;
+        UCHAR RetuningModes : 2;
+
+        UCHAR ClockMultiplier : 8;
+
+        UCHAR Reserved56 : 8;
+    };
+};
+static_assert(sizeof(SdRegCapabilities) == 8, "SdRegCapabilities");
+
+union SdRegHostControl1
+{
+    explicit constexpr
+    SdRegHostControl1(UINT8 u8)
+        : U8(u8) {}
+
+    UINT8 U8;
+    struct
+    {
+        UCHAR LedControl : 1;
+        UCHAR DataTransferWidth4 : 1;
+        UCHAR HighSpeedEnable : 1;
+        SdRegDma DmaSelect : 2;
+        UCHAR DataTransferWidth8 : 1;
+        UCHAR CardDetectTestLevel : 1;
+        UCHAR CardDetectTestSelect : 1;
+    };
+};
+static_assert(sizeof(SdRegHostControl1) == 1, "SdRegHostControl1");
+
+union SdRegHostControl2
+{
+    explicit constexpr
+    SdRegHostControl2(UINT16 u16)
+        : U16(u16) {}
+
+    UINT16 U16;
+    struct
+    {
+        SdRegUhs UhsModeSelect : 3;
+        UCHAR Signaling1_8 : 1;
+        SdRegDriverStrength DriverStrength : 2;
+        UCHAR ExecuteTuning : 1;
+        UCHAR SamplingClockSelect : 1;
+        UCHAR Uhs2Enable : 1;
+        UCHAR Reserved9 : 1;
+        UCHAR Adma2Length26Bit : 1;
+        UCHAR Cmd23Enable : 1;
+        UCHAR HostVersion4Enable : 1;
+        UCHAR Addressing64Bit : 1;
+        UCHAR AsynchronousInterruptEnable : 1;
+        UCHAR PresetValueEnable : 1;
+    };
+};
+static_assert(sizeof(SdRegHostControl2) == 2, "SdRegHostControl2");
+
+union SdRegBlockGapControl
+{
+    explicit constexpr
+    SdRegBlockGapControl(UINT8 u8)
+        : U8(u8) {}
+
+    UINT8 U8;
+    struct
+    {
+        UCHAR StopAtBlockGapRequest : 1;
+        UCHAR ContinueRequest : 1;
+        UCHAR ReadWaitControl : 1;
+        UCHAR InterruptAtBlockGap : 1;
+        UCHAR Reserved4 : 4;
+    };
+};
+static_assert(sizeof(SdRegBlockGapControl) == 1, "SdRegBlockGapControl");
+
+union SdRegClockControl
+{
+    explicit constexpr
+    SdRegClockControl(UINT16 u16)
+        : U16(u16) {}
+
+    UINT16 U16;
+    struct
+    {
+        UCHAR InternalClockEnable : 1;
+        UCHAR InternalClockStable : 1;
+        UCHAR SdClockEnable : 1;
+        UCHAR PllEnable : 1;
+        UCHAR Reserved4 : 1;
+        UCHAR ClockGeneratorProgrammable : 1;
+        UCHAR FrequencySelectUpper : 2;
+        UCHAR FrequencySelect : 8;
+    };
+};
+static_assert(sizeof(SdRegClockControl) == 2, "SdRegClockControl");
+
+union SdRegSoftwareReset
+{
+    explicit constexpr
+    SdRegSoftwareReset(UINT8 u8)
+        : U8(u8) {}
+
+    UINT8 U8;
+    struct
+    {
+        UCHAR ResetForAll : 1;
+        UCHAR ResetForCmdLine : 1;
+        UCHAR ResetForDatLine : 1;
+        UCHAR Reserved3 : 5;
+    };
+};
+static_assert(sizeof(SdRegSoftwareReset) == 1, "SdRegSoftwareReset");
+
+union SdRegTransferMode
+{
+    explicit constexpr
+    SdRegTransferMode(UINT16 u16)
+        : U16(u16) {}
+
+    UINT16 U16;
+    struct
+    {
+        UCHAR DmaEnable : 1;
+        UCHAR BlockCountEnable : 1;
+        SdRegAutoCmd AutoCmdEnable : 2;
+        UCHAR DataTransferDirectionRead : 1;
+        UCHAR MultipleBlock : 1;
+        UCHAR ResponseTypeR5 : 1;
+        UCHAR ResponseErrorCheckEnable : 1;
+        UCHAR ResponseInterruptDisable : 1;
+        UCHAR Reserved9 : 7;
+    };
+};
+static_assert(sizeof(SdRegTransferMode) == 2, "SdRegTransferMode");
+
+union SdRegCommand
+{
+    explicit constexpr
+    SdRegCommand(UINT16 u16)
+        : U16(u16) {}
+
+    UINT16 U16;
+    struct
+    {
+        SdRegResponse ResponseType : 2;
+        UCHAR SubCommand : 1;
+        UCHAR CommandCrcCheck : 1;
+        UCHAR CommandIndexCheck : 1;
+        UCHAR DataPresent : 1;
+        SdRegCommandType CommandType : 2;
+        UCHAR CommandIndex : 6;
+        UCHAR Reserved14 : 2;
+    };
+};
+static_assert(sizeof(SdRegCommand) == 2, "SdRegCommand");
+
+union SdRegPresentState
+{
+    explicit constexpr
+    SdRegPresentState(ULONG u32)
+        : U32(u32) {}
+
+    ULONG U32;
+    struct
+    {
+        UCHAR CommandInhibitCmd : 1;
+        UCHAR CommandInhibitDat : 1;
+        UCHAR DatLineActive : 1;
+        UCHAR ReTuningRequest : 1;
+        UCHAR EmbeddedDatSignalLevel : 4;
+
+        UCHAR WriteTransferActive : 1;
+        UCHAR ReadTransferActive : 1;
+        UCHAR BufferWriteEnable : 1;
+        UCHAR BufferReadEnable : 1;
+        UCHAR Reserved12 : 4;
+
+        UCHAR CardInserted : 1;
+        UCHAR CardStateStable : 1;
+        UCHAR CardDetect : 1;
+        UCHAR WriteEnabled : 1;
+        UCHAR SdDatSignalLevel : 4;
+
+        UCHAR SdCmdSignalLevel : 1;
+        UCHAR HostRegulatorVoltageStable : 1;
+        UCHAR Reserved26 : 1;
+        UCHAR CommandNotIssuedByError : 1;
+        UCHAR SubComandStatus : 1;
+        UCHAR InDormantState : 1;
+        UCHAR LaneSynchronization : 1;
+        UCHAR Uhs2IfDetection : 1;
+    };
+};
+static_assert(sizeof(SdRegPresentState) == 4, "SdRegPresentState");
+
+union SdRegNormalInterrupts
+{
+    explicit constexpr
+    SdRegNormalInterrupts(UINT16 u16)
+        : U16(u16) {}
+
+    UINT16 U16;
+    struct
+    {
+        UCHAR CommandComplete : 1;
+        UCHAR TransferComplete : 1;
+        UCHAR BlockGapEvent : 1;
+        UCHAR DmaInterrupt : 1;
+        UCHAR BufferWriteReady : 1;
+        UCHAR BufferReadReady : 1;
+        UCHAR CardInsertion : 1;
+        UCHAR CardRemoval : 1;
+        UCHAR CardInterrupt : 1;
+        UCHAR IntA : 1;
+        UCHAR IntB : 1;
+        UCHAR IntC : 1;
+        UCHAR ReTuningEvent : 1;
+        UCHAR FxEvent : 1;
+        UCHAR Reserved14 : 1;
+        UCHAR ErrorInterrupt : 1;
+    };
+};
+static_assert(sizeof(SdRegNormalInterrupts) == 2, "SdRegNormalInterrupts");
+
+union SdRegErrorInterrupts
+{
+    explicit constexpr
+    SdRegErrorInterrupts(UINT16 u16)
+        : U16(u16) {}
+
+    UINT16 U16;
+    struct
+    {
+        UCHAR CommandTimeout : 1;
+        UCHAR CommandCRC : 1;
+        UCHAR CommandEndBit : 1;
+        UCHAR CommandIndex : 1;
+        UCHAR DataTimeout : 1;
+        UCHAR DataCRC : 1;
+        UCHAR DataEndBit : 1;
+        UCHAR CurrentLimit : 1;
+        UCHAR AutoCmd : 1;
+        UCHAR Adma : 1;
+        UCHAR Tuning : 1;
+        UCHAR Response : 1;
+    };
+};
+static_assert(sizeof(SdRegErrorInterrupts) == 2, "SdRegErrorInterrupts");
+
+struct SdRegisters
+{
+    ULONG SdmaSystemAddress;            // 00
+    UINT16 BlockSize;                   // 04
+    UINT16 BlockCount16;                // 06
+    ULONG Argument;                     // 08
+    SdRegTransferMode TransferMode;     // 0C
+    SdRegCommand Command;               // 0E
+    ULONG Response32s[4];               // 10
+    ULONG BufferDataPort;               // 20
+    SdRegPresentState PresentState;     // 24
+    SdRegHostControl1 HostControl1;     // 28
+    SdRegPowerControl PowerControl;     // 29
+    SdRegBlockGapControl BlockGapControl;//2A
+    UINT8 WakeupControl;                // 2B
+    SdRegClockControl ClockControl;     // 2C
+    UINT8 TimeoutControl;               // 2E
+    SdRegSoftwareReset SoftwareReset;   // 2F
+    SdRegNormalInterrupts NormalInterruptStatus;       // 30
+    SdRegErrorInterrupts ErrorInterruptStatus;         // 32
+    SdRegNormalInterrupts NormalInterruptStatusEnable; // 34
+    SdRegErrorInterrupts ErrorInterruptStatusEnable;   // 36
+    SdRegNormalInterrupts NormalInterruptSignalEnable; // 38
+    SdRegErrorInterrupts ErrorInterruptSignalEnable;   // 3A
+    UINT16 AutoCmdErrorStatus;          // 3C
+    SdRegHostControl2 HostControl2;     // 3E
+    SdRegCapabilities Capabilities;     // 40
+    UINT8 MaximumCurrentVdd1[4];        // 48
+    UINT8 MaximumCurrentVdd2[4];        // 4C
+    UINT16 ForceEventAutoCmdError;      // 50
+    UINT16 ForceEventInterruptError;    // 52
+    UINT8 AdmaErrorStatus;              // 54
+    UINT8 Reserved55;                   // 55
+    UINT16 Reserved56;                  // 56
+    UINT64 AdmaSystemAddress;           // 58
+    UINT16 PresetValue16s[8];           // 60
+    ULONG Reserved70[32];               // 70 - ADMA3, UHS-II, vendor-specific stuff.
+    ULONG ReservedF0[3];                // F0
+    UINT16 SlotInterruptStatus;         // FC
+    SdRegSpecVersion SpecVersion;       // FE
+    UINT8 VendorVersion;                // FF
+};
+static_assert(sizeof(SdRegisters) == 0x100, "SdRegisters");

--- a/drivers/sd/bcm2711/brcme88c/SlotExtension.cpp
+++ b/drivers/sd/bcm2711/brcme88c/SlotExtension.cpp
@@ -1,0 +1,1481 @@
+/*
+Copyright 2021 Douglas Cook
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "precomp.h"
+#include "SlotExtension.h"
+#include "driver.h"
+#include "trace.h"
+#include "SdRegisters.h"
+
+struct DmaDescriptor
+{
+    // DMA-TODO
+};
+
+static constexpr SdRegNormalInterrupts
+EventMaskToInterruptMask(ULONG eventMask)
+{
+    return SdRegNormalInterrupts(static_cast<UINT16>(eventMask & 0xFFFF));
+}
+
+_Use_decl_annotations_ // = PASSIVE_LEVEL
+NTSTATUS CODE_SEG_PAGE
+SlotExtension::SlotInitialize(
+    PHYSICAL_ADDRESS physicalBase,
+    void* virtualBase,
+    ULONG length,
+    BOOLEAN crashdumpMode)
+{
+    // Similar sample code: SdhcSlotInitialize
+    PAGED_CODE();
+
+    memset(this, 0, sizeof(*this));
+
+    if (length < sizeof(SdRegisters))
+    {
+        LogError("SlotInitialize-BadLength",
+            TraceLoggingValue(length));
+        return STATUS_NOT_SUPPORTED;
+    }
+
+    m_registers = static_cast<SdRegisters*>(virtualBase);
+    m_physicalBase = physicalBase;
+    m_crashDumpMode = crashdumpMode != 0;
+    m_regulatorVoltage1_8 = false;
+
+    // BRCME88C: Voltage regulator control.
+    ULONG oldSignalingVoltageGpioState = 98; // 98 = Dummy "RPIQ not available" flag
+    if (DriverRpiqIsAvailable())
+    {
+        // For informational purposes, get existing voltage state.
+        MAILBOX_GET_SET_GPIO_EXPANDER info;
+        INIT_MAILBOX_GET_GPIO_EXPANDER(&info, SignalingVoltageGpio);
+        info.GpioState = 99; // 99 = Dummy "RPIQ query failed" flag.
+        DriverRpiqProperty(&info.Header);
+        oldSignalingVoltageGpioState = info.GpioState;
+
+        // Try to reset voltage regulator to 3.3.
+        SetRegulatorVoltage1_8(false);
+    }
+
+    SdRegSpecVersion const specVersion =
+        (SdRegSpecVersion)READ_REGISTER_UCHAR((UCHAR*)&m_registers->SpecVersion);
+    ULONG const maxCurrents = READ_REGISTER_ULONG((ULONG*)m_registers->MaximumCurrentVdd1);
+
+    SdRegCapabilities const regCaps(
+        READ_REGISTER_ULONG(&m_registers->Capabilities.U32s[0]),
+        READ_REGISTER_ULONG(&m_registers->Capabilities.U32s[1]));
+
+    NT_ASSERT(regCaps.BaseFrequencyForSdClock != 0);
+    NT_ASSERT(regCaps.MaxBlockLength < 3);
+    NT_ASSERT(regCaps.TimerCountForReTuning < 0x0f);
+    NT_ASSERT(regCaps.RetuningModes < 3);
+
+    m_capabilities.SpecVersion = (UCHAR)specVersion;
+
+    m_capabilities.MaximumOutstandingRequests = MaximumOutstandingRequests;
+
+    m_capabilities.MaximumBlockSize =
+        static_cast<USHORT>(512 << regCaps.MaxBlockLength);
+
+    m_capabilities.MaximumBlockCount = 0xffff;
+
+    m_capabilities.BaseClockFrequencyKhz =
+        regCaps.BaseFrequencyForSdClock * 1000;
+
+    m_capabilities.TuningTimerCountInSeconds =
+        regCaps.TimerCountForReTuning == 0
+        ? 0
+        : 1 << (regCaps.TimerCountForReTuning - 1);
+
+    m_capabilities.DmaDescriptorSize = sizeof(DmaDescriptor);
+
+    m_capabilities.AlignmentRequirement =
+        regCaps.SystemAddress64BitV3 ? 7 : 3;
+
+    m_capabilities.PioTransferMaxThreshold = 64;
+
+    // BRCME88C: 1.8v available only if RPIQ driver online.
+    bool const signalingVoltage18V = regCaps.DDR50 != 0 && DriverRpiqIsAvailable();
+
+    m_capabilities.Supported.ScatterGatherDma = false; // DMA-TODO: regCaps.Adma2 != 0;
+    m_capabilities.Supported.Address64Bit = regCaps.SystemAddress64BitV3 != 0;
+
+    // BRCME88C: Capabilities are wrong.
+    m_capabilities.Supported.BusWidth8Bit = false; // regCaps.DeviceBus8Bit != 0;
+
+    m_capabilities.Supported.HighSpeed = regCaps.HighSpeed != 0;
+    m_capabilities.Supported.SignalingVoltage18V = signalingVoltage18V;
+    m_capabilities.Supported.SDR50 = signalingVoltage18V && false; // TUNE-TODO: regCaps.SDR50 != 0;
+    m_capabilities.Supported.DDR50 = signalingVoltage18V;
+    m_capabilities.Supported.SDR104 = signalingVoltage18V && regCaps.SDR104 != 0;
+    m_capabilities.Supported.HS200 = false;
+    m_capabilities.Supported.HS400 = false;
+    m_capabilities.Supported.Reserved = 0;
+    m_capabilities.Supported.DriverTypeA = regCaps.DriverTypeA != 0;
+    m_capabilities.Supported.DriverTypeB = true;
+    m_capabilities.Supported.DriverTypeC = regCaps.DriverTypeC != 0;
+    m_capabilities.Supported.DriverTypeD = regCaps.DriverTypeD != 0;
+    m_capabilities.Supported.TuningForSDR50 = regCaps.UseTuningForSDR50 != 0;
+    m_capabilities.Supported.SoftwareTuning = regCaps.RetuningModes == 0;
+    m_capabilities.Supported.AutoCmd12 = true;
+    m_capabilities.Supported.AutoCmd23 = specVersion >= SdRegSpecVersion3;
+
+    // BRCME88C: We only support 1.8 for signaling, not for bus.
+    m_capabilities.Supported.Voltage18V = false; // regCaps.Voltage1_8 != 0;
+
+    m_capabilities.Supported.Voltage30V = regCaps.Voltage3_0 != 0;
+    m_capabilities.Supported.Voltage33V = regCaps.Voltage3_3 != 0;
+
+    // Assume that current is most restricted at the highest voltage.
+    unsigned const currentLimit = // In 4-milliamp increments
+        regCaps.Voltage3_3 ? (UCHAR)maxCurrents
+        : regCaps.Voltage3_0 ? (UCHAR)(maxCurrents >> 8)
+        : regCaps.Voltage1_8 ? (UCHAR)(maxCurrents >> 16)
+        : 0; // 0 is unexpected.
+    m_capabilities.Supported.Limit200mA = currentLimit >= 50;
+    m_capabilities.Supported.Limit400mA = currentLimit >= 100;
+    m_capabilities.Supported.Limit600mA = currentLimit >= 150;
+    m_capabilities.Supported.Limit800mA = currentLimit >= 200;
+    m_capabilities.Supported.SaveContext = false; // TODO?
+    m_capabilities.Supported.Reserved1 = 0;
+
+    m_capabilities.Flags.UsePioForRead = true;
+    m_capabilities.Flags.UsePioForWrite = true;
+    m_capabilities.Flags.Reserved = 0;
+
+    LogInfo("SlotInitialize",
+        TraceLoggingUInt16(m_capabilities.SpecVersion, "SpecVersion"),
+        TraceLoggingHexUInt8Array((UINT8*)&maxCurrents, 4, "Vdd1Max"),
+        TraceLoggingHexInt64(regCaps.U64, "Capabilities"),
+        TraceLoggingPointer((void*)m_registers, "Registers"),
+        TraceLoggingUInt32(oldSignalingVoltageGpioState, "OldRegulator"));
+    return STATUS_SUCCESS;
+}
+
+_Use_decl_annotations_ // = PASSIVE_LEVEL
+void CODE_SEG_PAGE
+SlotExtension::SlotGetSlotCapabilities(
+    SDPORT_CAPABILITIES* capabilities)
+{
+    PAGED_CODE();
+    *capabilities = m_capabilities;
+    return;
+}
+
+_Use_decl_annotations_ // <= APC_LEVEL
+NTSTATUS CODE_SEG_PAGE
+SlotExtension::SlotIssueBusOperation(
+    SDPORT_BUS_OPERATION const& busOperation)
+{
+    // Similar sample code: SdhcSlotIssueBusOperation
+    PAGED_CODE();
+
+    NTSTATUS status;
+
+    switch (busOperation.Type)
+    {
+    case SdResetHw:
+        status = ResetHw();
+        break;
+
+    case SdResetHost:
+        status = ResetHost(busOperation.Parameters.ResetType);
+        break;
+
+    case SdSetClock:
+        status = SetClock(busOperation.Parameters.FrequencyKhz);
+        break;
+
+    case SdSetVoltage:
+        status = SetVoltage(busOperation.Parameters.Voltage);
+        break;
+
+    case SdSetPower:
+        // Not actually used - sdport seems to only use SdSetVoltage.
+        LogError("SetPower-NotSupported",
+            TraceLoggingBoolean(busOperation.Parameters.PowerEnabled, "PowerEnabled"));
+        status = STATUS_NOT_SUPPORTED;
+        break;
+
+    case SdSetBusWidth:
+        status = SetBusWidth(busOperation.Parameters.BusWidth);
+        break;
+
+    case SdSetBusSpeed:
+        status = SetBusSpeed(busOperation.Parameters.BusSpeed);
+        break;
+
+    case SdSetSignalingVoltage:
+        status = SetSignalingVoltage(busOperation.Parameters.SignalingVoltage);
+        break;
+
+    case SdSetDriveStrength:
+        // Not actually used - sdport seems to only use SdSetDriverType.
+        LogError("SetDriveStrength-NotSupported",
+            TraceLoggingUInt32(busOperation.Parameters.DriveStrength, "DriveStrength"));
+        status = STATUS_NOT_SUPPORTED;
+        break;
+
+    case SdSetDriverType:
+        status = SetDriverType(busOperation.Parameters.DriverType);
+        break;
+
+    case SdSetPresetValue:
+        status = SetPresetValue(busOperation.Parameters.PresetValueEnabled != 0);
+        break;
+
+    case SdSetBlockGapInterrupt:
+        status = SetBlockGapInterrupt(busOperation.Parameters.BlockGapIntEnabled != 0);
+        break;
+
+    case SdExecuteTuning:
+        status = ExecuteTuning();
+        break;
+
+    default:
+        LogError("IssueBusOperation-BadType",
+            TraceLoggingUInt32(busOperation.Type, "Type"),
+            TraceLoggingHexInt32(busOperation.Parameters.FrequencyKhz, "Parameters"));
+        status = STATUS_NOT_SUPPORTED;
+        break;
+    }
+
+    return status;
+}
+
+_Use_decl_annotations_ // = PASSIVE_LEVEL
+BOOLEAN CODE_SEG_PAGE
+SlotExtension::SlotGetCardDetectState()
+{
+    // Similar sample code: SdhcIsCardInserted
+    PAGED_CODE();
+
+    SdRegPresentState presentState(READ_REGISTER_ULONG(&m_registers->PresentState.U32));
+    bool const cardInserted = presentState.CardInserted != 0;
+
+    LogVerbose("GetCardDetectState",
+        TraceLoggingValue(cardInserted, "CardInserted"));
+    return cardInserted;
+}
+
+_Use_decl_annotations_ // <= DISPATCH_LEVEL
+BOOLEAN CODE_SEG_TEXT
+SlotExtension::SlotGetWriteProtectState()
+{
+    // Similar sample code: SdhcIsWriteProtected
+
+    SdRegPresentState presentState(READ_REGISTER_ULONG(&m_registers->PresentState.U32));
+    bool const writeProtected = presentState.WriteEnabled == 0;
+
+    LogVerbose("GetWriteProtectState",
+        TraceLoggingValue(writeProtected));
+    return writeProtected;
+}
+
+_Use_decl_annotations_ // <= HIGH_LEVEL
+BOOLEAN CODE_SEG_TEXT
+SlotExtension::SlotInterrupt(
+    ULONG* events,
+    ULONG* errors,
+    BOOLEAN* notifyCardChange,
+    BOOLEAN* notifySdioInterrupt,
+    BOOLEAN* notifyTuning)
+{
+    // Similar sample code: SdhcSlotInterrupt
+
+    bool clearedAnything;
+
+    SdRegNormalInterrupts const interrupts(
+        READ_REGISTER_USHORT(&m_registers->NormalInterruptStatus.U16));
+
+    if (interrupts.U16 == 0 || interrupts.U16 == 0xFFFF)
+    {
+        // 0xFFFF means controller is offline and interrupts are not real.
+        *events = 0;
+        *errors = 0;
+        *notifyCardChange = false;
+        *notifySdioInterrupt = false;
+        *notifyTuning = false;
+        clearedAnything = false;
+    }
+    else
+    {
+        // Make a copy of interrupts, but clear flags that will be reported
+        // in errors, notifyCardChange, notifySdioInterrupt, or notifyTuning.
+        SdRegNormalInterrupts unreported = interrupts;
+        unreported.CardInsertion = false;
+        unreported.CardRemoval = false;
+        unreported.CardInterrupt = false;
+        unreported.ReTuningEvent = false;
+        unreported.ErrorInterrupt;
+
+        *events = unreported.U16;
+        *errors = interrupts.ErrorInterrupt
+            ? READ_REGISTER_USHORT(&m_registers->ErrorInterruptStatus.U16)
+            : 0;
+        *notifyCardChange = interrupts.CardInsertion || interrupts.CardRemoval;
+        *notifySdioInterrupt = interrupts.CardInterrupt != 0;
+        *notifyTuning = interrupts.ReTuningEvent != 0;
+
+        AcknowledgeInterrupts(interrupts);
+        clearedAnything = true;
+    }
+
+    return clearedAnything;
+}
+
+_Use_decl_annotations_ // = DISPATCH_LEVEL
+NTSTATUS CODE_SEG_TEXT
+SlotExtension::SlotIssueRequest(
+    _Inout_ SDPORT_REQUEST* request)
+{
+    // Similar sample code: SdhcSlotIssueRequest
+
+    NTSTATUS status;
+
+    switch (request->Type)
+    {
+    case SdRequestTypeCommandNoTransfer:
+    case SdRequestTypeCommandWithTransfer:
+        status = SendCommand(request);
+        break;
+
+    case SdRequestTypeStartTransfer:
+        switch (request->Command.TransferMethod)
+        {
+        case SdTransferMethodPio:
+            status = StartPioTransfer(request);
+            break;
+        case SdTransferMethodSgDma:
+            status = StartDmaTransfer(request);
+            break;
+        default:
+            LogError("IssueRequest-BadMethod",
+                TraceLoggingUInt32(request->Command.TransferMethod, "TransferMethod"));
+            status = STATUS_NOT_SUPPORTED;
+            break;
+        }
+        break;
+
+    default:
+        LogError("IssueRequest-BadType",
+            TraceLoggingUInt32(request->Command.TransferMethod, "Type"));
+        status = STATUS_NOT_SUPPORTED;
+        break;
+    }
+
+    return status;
+}
+
+_Use_decl_annotations_ // <= DISPATCH_LEVEL
+void CODE_SEG_TEXT
+SlotExtension::SlotGetResponse(
+    SDPORT_COMMAND const& command,
+    void* responseBuffer)
+{
+    // Similar sample code: SdhcGetResponse
+
+    // TODO: AutoCmd responses are in high registers. Do we care?
+
+    UINT16 responseLength;
+    switch (command.ResponseType)
+    {
+    case SdResponseTypeNone:
+        responseLength = 0;
+        break;
+
+    case SdResponseTypeR1:
+    case SdResponseTypeR1B:
+    case SdResponseTypeR3:
+    case SdResponseTypeR4:
+    case SdResponseTypeR5:
+    case SdResponseTypeR5B:
+    case SdResponseTypeR6:
+        // 4-byte response:
+        responseLength = 4;
+        break;
+
+    case SdResponseTypeR2:
+        // 16-byte response:
+        responseLength = 16;
+        break;
+
+    default:
+        LogError("GetResponse-BadType",
+            TraceLoggingUInt32(command.ResponseType, "ResponseType"));
+        return;
+    }
+
+    READ_REGISTER_BUFFER_ULONG(m_registers->Response32s, (ULONG*)responseBuffer, responseLength / 4);
+
+    LogVerboseInfo("GetResponse",
+        TraceLoggingUInt32(command.ResponseType, "ResponseType"),
+        TraceLoggingHexInt32Array((INT32*)responseBuffer, responseLength / 4, "Data"));
+    return;
+}
+
+_Use_decl_annotations_ // <= HIGH_LEVEL
+void CODE_SEG_TEXT
+SlotExtension::SlotToggleEvents(
+    ULONG eventMask,
+    BOOLEAN enable)
+{
+    // Similar sample code: SdhcSlotToggleEvents, SdhcEnableInterrupt, SdhcDisableInterrupt
+
+    auto const interruptMask = EventMaskToInterruptMask(eventMask);
+
+    auto const oldEnable = SdRegNormalInterrupts(
+        READ_REGISTER_USHORT(&m_registers->NormalInterruptSignalEnable.U16));
+
+    if (enable)
+    {
+        SdRegNormalInterrupts const newEnable(oldEnable.U16 | interruptMask.U16);
+        if (!m_crashDumpMode)
+        {
+            // Enable signals to OS.
+
+            WRITE_REGISTER_USHORT(&m_registers->NormalInterruptSignalEnable.U16, newEnable.U16);
+            WRITE_REGISTER_USHORT(&m_registers->ErrorInterruptSignalEnable.U16, 0xffff);
+        }
+
+        // Enable signals on controller.
+
+        WRITE_REGISTER_USHORT(&m_registers->NormalInterruptStatusEnable.U16, newEnable.U16);
+        WRITE_REGISTER_USHORT(&m_registers->ErrorInterruptStatusEnable.U16, 0xffff);
+    }
+    else
+    {
+        SdRegNormalInterrupts const newEnable(oldEnable.U16 & ~interruptMask.U16);
+
+        // Disable signals on controller.
+
+        WRITE_REGISTER_USHORT(&m_registers->NormalInterruptStatusEnable.U16, newEnable.U16);
+        WRITE_REGISTER_USHORT(&m_registers->ErrorInterruptStatusEnable.U16, 0);
+
+        // Disable signals to OS.
+
+        WRITE_REGISTER_USHORT(&m_registers->NormalInterruptSignalEnable.U16, newEnable.U16);
+        WRITE_REGISTER_USHORT(&m_registers->ErrorInterruptSignalEnable.U16, 0);
+    }
+
+    LogVerboseInfo("ToggleEvents",
+        TraceLoggingBoolean(enable, "Enable"),
+        TraceLoggingHexInt32(eventMask, "EventMask"),
+        TraceLoggingHexInt16(READ_REGISTER_USHORT(&m_registers->NormalInterruptSignalEnable.U16), "NormalSignal"));
+    return;
+}
+
+_Use_decl_annotations_ // <= HIGH_LEVEL
+void CODE_SEG_TEXT
+SlotExtension::SlotClearEvents(
+    ULONG eventMask)
+{
+    // Similar sample code: SdhcSlotClearEvents
+
+    auto const interruptMask = EventMaskToInterruptMask(eventMask);
+    AcknowledgeInterrupts(interruptMask);
+    return;
+}
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+static NTSTATUS CODE_SEG_TEXT
+ErrorInterruptToStatus(SdRegErrorInterrupts errorInterrupts)
+{
+    NTSTATUS status;
+
+    if (errorInterrupts.U16 == 0)
+    {
+        status = STATUS_SUCCESS;
+    }
+    else if (errorInterrupts.CommandTimeout || errorInterrupts.DataTimeout)
+    {
+        status = STATUS_IO_TIMEOUT;
+    }
+    else if (errorInterrupts.CommandCRC || errorInterrupts.DataCRC)
+    {
+        status = STATUS_CRC_ERROR;
+    }
+    else if (errorInterrupts.CommandEndBit || errorInterrupts.DataEndBit)
+    {
+        status = STATUS_DEVICE_DATA_ERROR;
+    }
+    else if (errorInterrupts.CommandIndex)
+    {
+        status = STATUS_DEVICE_PROTOCOL_ERROR;
+    }
+    else if (errorInterrupts.CurrentLimit)
+    {
+        status = STATUS_DEVICE_POWER_FAILURE;
+    }
+    else
+    {
+        status = STATUS_IO_DEVICE_ERROR;
+    }
+
+    return status;
+}
+
+_Use_decl_annotations_ // = DISPATCH_LEVEL
+void CODE_SEG_TEXT
+SlotExtension::SlotRequestDpc(
+    SDPORT_REQUEST* request,
+    ULONG events,
+    ULONG errors)
+{
+    // Similar sample code: SdhcRequestDpc
+
+    auto const originalRequired =
+        InterlockedAndNoFence((long*)&request->RequiredEvents, ~events);
+
+    if (errors != 0)
+    {
+        SdRegErrorInterrupts const errorInterrupts(static_cast<UINT16>(errors));
+        NTSTATUS const status = ErrorInterruptToStatus(errorInterrupts);
+
+        LogWarning("RequestDpc-Error",
+            TraceLoggingPointer(request),
+            TraceLoggingNTStatus(status),
+            TraceLoggingHexInt32(originalRequired, "RequiredEvents"),
+            TraceLoggingHexInt32(events, "Events"),
+            TraceLoggingHexInt32(errors, "Errors"));
+        InterlockedAndNoFence((long*)&request->RequiredEvents, 0);
+        SdPortCompleteRequest(request, status);
+    }
+    else if ((originalRequired & ~events) == 0)
+    {
+        NTSTATUS status = request->Status;
+        if (status != STATUS_MORE_PROCESSING_REQUIRED)
+        {
+            status = STATUS_SUCCESS;
+            request->Status = status;
+        }
+
+        LogVerboseInfo("RequestDpc-Complete",
+            TraceLoggingPointer(request),
+            TraceLoggingNTStatus(status),
+            TraceLoggingHexInt32(events, "Events"));
+        SdPortCompleteRequest(request, status);
+    }
+    else
+    {
+        LogVerboseInfo("RequestDpc-Partial",
+            TraceLoggingPointer(request),
+            TraceLoggingHexInt32(originalRequired, "RequiredEvents"),
+            TraceLoggingHexInt32(events, "Events"));
+    }
+
+    return;
+}
+
+_Use_decl_annotations_ // <= DISPATCH_LEVEL
+void CODE_SEG_TEXT
+SlotExtension::SlotSaveContext()
+{
+    LogError("SaveContext"); // Unexpected
+    return;
+}
+
+_Use_decl_annotations_ // <= DISPATCH_LEVEL
+void CODE_SEG_TEXT
+SlotExtension::SlotRestoreContext()
+{
+    LogError("SlotRestoreContext"); // Unexpected
+    return;
+}
+
+_Use_decl_annotations_ // <= APC_LEVEL
+NTSTATUS CODE_SEG_PAGE
+SlotExtension::SetRegulatorVoltage1_8(bool regulatorVoltage1_8)
+{
+    PAGED_CODE();
+
+    NTSTATUS status;
+    MAILBOX_GET_SET_GPIO_EXPANDER info;
+
+    LogInfo("SetRegulatorVoltage1_8-Entry",
+        TraceLoggingUInt8(regulatorVoltage1_8, "requested"));
+
+    INIT_MAILBOX_SET_GPIO_EXPANDER(&info, SignalingVoltageGpio, regulatorVoltage1_8);
+    status = DriverRpiqProperty(&info.Header);
+    if (NT_SUCCESS(status))
+    {
+        m_regulatorVoltage1_8 = regulatorVoltage1_8;
+    }
+
+    LogInfo("SetRegulatorVoltage1_8",
+        TraceLoggingUInt8(regulatorVoltage1_8, "requested"),
+        TraceLoggingNTStatus(status));
+
+    return status;
+}
+
+_Use_decl_annotations_ // <= HIGH_LEVEL
+void CODE_SEG_TEXT
+SlotExtension::AcknowledgeInterrupts(SdRegNormalInterrupts interruptMask)
+{
+    if (interruptMask.ErrorInterrupt)
+    {
+        WRITE_REGISTER_USHORT(&m_registers->ErrorInterruptStatus.U16, 0xffff);
+    }
+
+    WRITE_REGISTER_USHORT(&m_registers->NormalInterruptStatus.U16, interruptMask.U16);
+    return;
+}
+
+_Use_decl_annotations_ // = DISPATCH_LEVEL
+NTSTATUS CODE_SEG_TEXT
+SlotExtension::SendCommand(_Inout_ SDPORT_REQUEST* request)
+{
+    // Similar sample code: SdhcSendCommand
+
+    SdRegCommand command(0);
+    SdRegTransferMode transferMode(0);
+    SdRegNormalInterrupts requiredEvents(0);
+
+    NT_ASSERT(
+        request->Type == SdRequestTypeCommandNoTransfer ||
+        request->Type == SdRequestTypeCommandWithTransfer);
+
+    // Determine value for command:
+
+    command.CommandIndex = request->Command.Index;
+    command.DataPresent = SdTransferTypeNone != request->Command.TransferType;
+
+    switch (request->Command.ResponseType)
+    {
+    case SdResponseTypeNone:
+        break;
+
+    case SdResponseTypeR1:
+    case SdResponseTypeR5:
+    case SdResponseTypeR6:
+        command.ResponseType = SdRegResponse48;
+        command.CommandCrcCheck = true;
+        command.CommandIndexCheck = true;
+        break;
+
+    case SdResponseTypeR1B:
+    case SdResponseTypeR5B:
+        command.ResponseType = SdRegResponse48CheckBusy;
+        command.CommandCrcCheck = true;
+        command.CommandIndexCheck = true;
+        requiredEvents.TransferComplete = true;
+        break;
+
+    case SdResponseTypeR2:
+        command.ResponseType = SdRegResponse136;
+        command.CommandCrcCheck = true;
+        break;
+
+    case SdResponseTypeR3:
+    case SdResponseTypeR4:
+        command.ResponseType = SdRegResponse48;
+        break;
+
+    default:
+        LogError("SendCommand-BadResponseType",
+            TraceLoggingUInt32(request->Command.ResponseType, "ResponseType"));
+        return STATUS_NOT_SUPPORTED;
+    }
+
+    switch (request->Command.Type)
+    {
+    case SdCommandTypeUndefined: // Normal
+    case SdCommandTypeSuspend:
+    case SdCommandTypeResume:
+    case SdCommandTypeAbort:
+        command.CommandType = (SdRegCommandType)request->Command.Type;
+        break;
+    default:
+        LogError("SendCommand-BadCommandType",
+            TraceLoggingUInt32(request->Command.Type, "Type"));
+        return STATUS_NOT_SUPPORTED;
+    }
+
+    // Determine value for transferMode:
+
+    switch (request->Command.TransferType)
+    {
+    case SdTransferTypeNone:
+        NT_ASSERT(request->Command.BlockCount == 0);
+        break;
+
+    case SdTransferTypeSingleBlock:
+        NT_ASSERT(request->Command.BlockCount == 1);
+        __fallthrough;
+
+    case SdTransferTypeMultiBlock:
+    case SdTransferTypeMultiBlockNoStop:
+
+        NT_ASSERT(request->Command.BlockCount != 0);
+        transferMode.DataTransferDirectionRead =
+            (SdTransferDirectionRead == request->Command.TransferDirection);
+
+        switch (request->Command.TransferMethod)
+        {
+        case SdTransferMethodPio:
+
+            switch (request->Command.TransferDirection)
+            {
+            case SdTransferDirectionRead:
+                requiredEvents.BufferReadReady = true;
+                break;
+            case SdTransferDirectionWrite:
+                requiredEvents.BufferWriteReady = true;
+                break;
+            default:
+                LogError("SendCommand-BadTransferDirection",
+                    TraceLoggingUInt32(request->Command.TransferDirection, "TransferDirection"));
+                return STATUS_NOT_SUPPORTED;
+            }
+
+            break;
+
+        case SdTransferMethodSgDma:
+            //requiredEvents.TransferComplete = true;
+
+        default:
+            LogError("SendCommand-BadTransferMethod",
+                TraceLoggingUInt32(request->Command.TransferMethod, "TransferMethod"));
+            return STATUS_NOT_SUPPORTED;
+        }
+        break;
+
+    default:
+
+        LogError("SendCommand-BadTransferType",
+            TraceLoggingUInt32(request->Command.TransferType, "TransferType"));
+        return STATUS_NOT_SUPPORTED;
+    }
+
+    if (request->Command.BlockCount > 1)
+    {
+        transferMode.BlockCountEnable = true;
+        transferMode.MultipleBlock = true;
+        transferMode.AutoCmdEnable = SdRegAutoCmd12Enable;
+    }
+
+    // Start the command:
+
+    requiredEvents.CommandComplete = true;
+    InterlockedExchangeNoFence((long*)&request->RequiredEvents, requiredEvents.U16);
+
+    WRITE_REGISTER_ULONG(&m_registers->SdmaSystemAddress, 0);
+    WRITE_REGISTER_USHORT(&m_registers->BlockSize, request->Command.BlockSize);
+    WRITE_REGISTER_USHORT(&m_registers->BlockCount16, request->Command.BlockCount);
+    WRITE_REGISTER_ULONG(&m_registers->Argument, request->Command.Argument);
+    WRITE_REGISTER_USHORT(&m_registers->TransferMode.U16, transferMode.U16);
+
+    LogVerboseInfo("SendCommand",
+        TraceLoggingUInt8(request->Command.Index, "CMD"),
+        TraceLoggingHexInt32(request->Command.Argument, "ARG"),
+        TraceLoggingHexInt16(command.U16, "CommandReg"),
+        TraceLoggingHexInt16(transferMode.U16, "TransferMode"),
+        TraceLoggingHexInt16(requiredEvents.U16, "RequiredEvents"));
+    WRITE_REGISTER_USHORT(&m_registers->Command.U16, command.U16);
+
+    return STATUS_PENDING;
+}
+
+_Use_decl_annotations_ // = DISPATCH_LEVEL
+NTSTATUS CODE_SEG_TEXT
+SlotExtension::StartPioTransfer(SDPORT_REQUEST* request)
+{
+    // Similar sample code: SdhcStartPioTransfer
+
+    NT_ASSERT(request->Type == SdRequestTypeStartTransfer);
+    NT_ASSERT(request->Command.TransferMethod == SdTransferMethodPio);
+    NT_ASSERT(request->Command.BlockCount != 0);
+
+    unsigned const LongSize = sizeof(ULONG);
+    unsigned const LongMask = LongSize - 1;
+    auto const blockSize = request->Command.BlockSize;
+    auto const blockCount = blockSize / LongSize;
+
+    switch (request->Command.TransferDirection)
+    {
+    case SdTransferDirectionRead:
+
+        if (blockCount != 0)
+        {
+            // Only need a fence before the first read.
+            *(ULONG*)&request->Command.DataBuffer[0] =
+                READ_REGISTER_ULONG(&m_registers->BufferDataPort);
+
+            for (unsigned i = 1; i < blockCount; i += 1)
+            {
+                ((ULONG*)request->Command.DataBuffer)[i] =
+                    READ_REGISTER_NOFENCE_ULONG(&m_registers->BufferDataPort);
+            }
+        }
+
+        if (blockSize & LongMask)
+        {
+            READ_REGISTER_BUFFER_UCHAR((UCHAR*)&m_registers->BufferDataPort,
+                &request->Command.DataBuffer[blockCount * LongSize],
+                blockSize & LongMask);
+        }
+
+        break;
+
+    case SdTransferDirectionWrite:
+
+        if (blockCount != 0)
+        {
+            for (unsigned i = 0; i < blockCount - 1; i += 1)
+            {
+                WRITE_REGISTER_NOFENCE_ULONG(&m_registers->BufferDataPort,
+                    ((ULONG*)request->Command.DataBuffer)[i]);
+            }
+
+            // Only need a fence after the last write.
+            WRITE_REGISTER_ULONG(&m_registers->BufferDataPort,
+                ((ULONG*)request->Command.DataBuffer)[blockCount - 1]);
+        }
+
+        if (blockSize & LongMask)
+        {
+            WRITE_REGISTER_BUFFER_UCHAR((UCHAR*)&m_registers->BufferDataPort,
+                &request->Command.DataBuffer[blockCount * LongSize],
+                blockSize & LongMask);
+        }
+
+        break;
+
+    default:
+
+        LogError("StartPioTransfer-BadTransferDirection",
+            TraceLoggingUInt32(request->Command.TransferDirection, "TransferDirection"));
+        return STATUS_NOT_SUPPORTED;
+    }
+
+    request->Command.BlockCount -= 1;
+    request->Command.DataBuffer += request->Command.BlockSize;
+
+    SdRegNormalInterrupts requiredEvents(0);
+    if (request->Command.BlockCount == 0)
+    {
+        requiredEvents.TransferComplete = true;
+        request->Status = STATUS_SUCCESS;
+    }
+    else
+    {
+        if (request->Command.TransferDirection == SdTransferDirectionRead)
+        {
+            requiredEvents.BufferReadReady = true;
+        }
+        else
+        {
+            requiredEvents.BufferWriteReady = true;
+        }
+
+        request->Status = STATUS_MORE_PROCESSING_REQUIRED;
+    }
+
+    InterlockedOrNoFence((long*)&request->RequiredEvents, requiredEvents.U16);
+
+    LogVerboseInfo("StartPioTransfer",
+        TraceLoggingUInt16(blockSize, "BlockSize"));
+    return STATUS_PENDING;
+}
+
+_Use_decl_annotations_ // = DISPATCH_LEVEL
+NTSTATUS CODE_SEG_TEXT
+SlotExtension::StartDmaTransfer(SDPORT_REQUEST* request)
+{
+    // Similar sample code: SdhcStartAdmaTransfer
+
+    LogError("StartDmaTransfer",
+        TraceLoggingUInt32(request->Command.TransferDirection, "TransferDirection"));
+    return STATUS_NOT_IMPLEMENTED; // DMA-TODO
+}
+
+_Use_decl_annotations_ // <= APC_LEVEL
+NTSTATUS CODE_SEG_PAGE
+SlotExtension::ResetHw()
+{
+    PAGED_CODE();
+
+    SdRegClockControl clockControl(READ_REGISTER_USHORT(&m_registers->ClockControl.U16));
+    clockControl.SdClockEnable = false;
+    WRITE_REGISTER_USHORT(&m_registers->ClockControl.U16, clockControl.U16);
+    clockControl.U16 = 0;
+    WRITE_REGISTER_USHORT(&m_registers->ClockControl.U16, clockControl.U16);
+
+    SdRegPowerControl powerControl(READ_REGISTER_UCHAR(&m_registers->PowerControl.U8));
+    powerControl.Vdd1Power = false;
+    WRITE_REGISTER_UCHAR(&m_registers->PowerControl.U8, powerControl.U8);
+    powerControl.U8 = 0;
+    WRITE_REGISTER_UCHAR(&m_registers->PowerControl.U8, powerControl.U8);
+
+    LogInfo("ResetHw",
+        TraceLoggingHexInt8(READ_REGISTER_UCHAR((UCHAR*)&m_registers->SoftwareReset), "SoftwareReset"),
+        TraceLoggingHexInt32(READ_REGISTER_ULONG(&m_registers->PresentState.U32), "PresentState"),
+        TraceLoggingHexInt32(READ_REGISTER_UCHAR(&m_registers->HostControl1.U8), "HostControl1"),
+        TraceLoggingHexInt32(READ_REGISTER_USHORT(&m_registers->HostControl2.U16), "HostControl2"),
+        TraceLoggingHexInt32(READ_REGISTER_UCHAR(&m_registers->TimeoutControl), "TimeoutControl"));
+    return STATUS_SUCCESS;
+}
+
+_Use_decl_annotations_ // <= APC_LEVEL
+NTSTATUS CODE_SEG_PAGE
+SlotExtension::ResetHost(SDPORT_RESET_TYPE resetType)
+{
+    // Similar sample code: SdhcResetHost
+    PAGED_CODE();
+
+    SdRegSoftwareReset resetReg(0);
+    switch (resetType)
+    {
+    case SdResetTypeAll:
+        // BRCME88C TODO: Should probably reset regulator to v3.3 here.
+        // Unfortunately, calling RPIQ here causes deadlock in some code paths.
+        resetReg.ResetForAll = true;
+        break;
+    case SdResetTypeCmd:
+        resetReg.ResetForCmdLine = true;
+        break;
+    case SdResetTypeDat:
+        resetReg.ResetForDatLine = true;
+        break;
+    default:
+        LogError("ResetHost-BadType",
+            TraceLoggingUInt32(resetType, "ResetType"));
+        return STATUS_NOT_SUPPORTED;
+    }
+
+    WRITE_REGISTER_UCHAR(&m_registers->SoftwareReset.U8, resetReg.U8);
+
+    // Wait until the requested operation is no longer in progress.
+    for (unsigned i = 0;; i += 1)
+    {
+        if (0 == (resetReg.U8 & READ_REGISTER_UCHAR(&m_registers->SoftwareReset.U8)))
+        {
+            break;
+        }
+
+        if (i == RetryMaxCount)
+        {
+            LogError("ResetHost-Timeout",
+                TraceLoggingUInt32(resetType, "ResetType"));
+            return STATUS_IO_TIMEOUT;
+        }
+
+        SdPortWait(RetryWaitMicroseconds);
+    }
+
+    WRITE_REGISTER_UCHAR(&m_registers->TimeoutControl, DataTimeoutCounterValue);
+
+    LogInfo("ResetHost",
+        TraceLoggingUInt32(resetType, "ResetType"),
+        TraceLoggingHexInt8(READ_REGISTER_UCHAR((UCHAR*)&m_registers->SoftwareReset), "SoftwareReset"),
+        TraceLoggingHexInt32(READ_REGISTER_ULONG(&m_registers->PresentState.U32), "PresentState"),
+        TraceLoggingHexInt32(READ_REGISTER_UCHAR(&m_registers->HostControl1.U8), "HostControl1"),
+        TraceLoggingHexInt32(READ_REGISTER_USHORT(&m_registers->HostControl2.U16), "HostControl2"));
+    return STATUS_SUCCESS;
+}
+
+_Use_decl_annotations_ // <= APC_LEVEL
+NTSTATUS CODE_SEG_PAGE
+SlotExtension::SetClock(ULONG frequencyKhz)
+{
+    // Similar sample code: SdhcSetClock
+    PAGED_CODE();
+
+    SdRegClockControl clockControl(READ_REGISTER_USHORT(&m_registers->ClockControl.U16));
+
+    if (frequencyKhz == 0)
+    {
+        // Stop clock.
+        clockControl.SdClockEnable = false;
+        WRITE_REGISTER_USHORT(&m_registers->ClockControl.U16, clockControl.U16);
+    }
+    else
+    {
+        // Compute new clock divisor.
+        unsigned clockDivisor;
+        if (m_capabilities.BaseClockFrequencyKhz <= frequencyKhz)
+        {
+            clockDivisor = 1;
+        }
+        else if (m_capabilities.SpecVersion < SdRegSpecVersion3)
+        {
+            // SdReg 1.0 and 2.0 can divide by powers of 2 from 2..256.
+            // Could do fancy bit manipulation, but easier to just try 8 possibilities
+            // and stop at the first one that meets our requirements.
+
+            UINT8 clockShift;
+            for (clockShift = 1; clockShift != 9; clockShift += 1)
+            {
+                if ((m_capabilities.BaseClockFrequencyKhz >> clockShift) <= frequencyKhz)
+                {
+                    // Found a divisor that results in actual <= target.
+                    break;
+                }
+            }
+
+            if (clockShift == 9)
+            {
+                LogError("SetClock-BadFreqV2",
+                    TraceLoggingUInt32(frequencyKhz, "FrequencyKhz"));
+                return STATUS_NOT_SUPPORTED;
+            }
+
+            clockDivisor = 1u << clockShift;
+        }
+        else
+        {
+            // SdReg 3.0 and later can divide by any even value 2..2046.
+
+            clockDivisor = m_capabilities.BaseClockFrequencyKhz / frequencyKhz;
+            clockDivisor &= ~1u; // Only even values.
+
+            // The above rounded down, but we wanted to round up.
+            if (m_capabilities.BaseClockFrequencyKhz > frequencyKhz * clockDivisor)
+            {
+                clockDivisor += 2;
+            }
+
+            if (clockDivisor > 2046)
+            {
+                LogError("SetClock-BadFreqV3",
+                    TraceLoggingUInt32(frequencyKhz, "FrequencyKhz"));
+                return STATUS_NOT_SUPPORTED;
+            }
+        }
+
+        // Stop clock.
+        clockControl.InternalClockEnable = false;
+        clockControl.SdClockEnable = false;
+        WRITE_REGISTER_USHORT(&m_registers->ClockControl.U16, clockControl.U16);
+
+        // Set up a new Clock Control register.
+        clockControl = SdRegClockControl(0);
+        clockControl.FrequencySelect = (UCHAR)(clockDivisor >> 1);
+        clockControl.FrequencySelectUpper = (UCHAR)(clockDivisor >> 9);
+
+        // Start clock.
+        clockControl.InternalClockEnable = true;
+        WRITE_REGISTER_USHORT(&m_registers->ClockControl.U16, clockControl.U16);
+
+        // Wait until clock is stable.
+        for (unsigned i = 0;; i += 1)
+        {
+            clockControl.U16 = READ_REGISTER_USHORT(&m_registers->ClockControl.U16);
+            if (clockControl.InternalClockStable)
+            {
+                break;
+            }
+
+            if (i == RetryMaxCount)
+            {
+                LogError("SetClock-Timeout",
+                    TraceLoggingUInt32(frequencyKhz, "FrequencyKhz"));
+                return STATUS_IO_TIMEOUT;
+            }
+
+            SdPortWait(RetryWaitMicroseconds);
+        }
+
+        clockControl.SdClockEnable = true;
+        WRITE_REGISTER_USHORT(&m_registers->ClockControl.U16, clockControl.U16);
+    }
+
+    LogInfo("SetClock",
+        TraceLoggingUInt32(frequencyKhz, "FrequencyKhz"),
+        TraceLoggingHexInt16(READ_REGISTER_USHORT(&m_registers->ClockControl.U16), "ClockControl"));
+    return STATUS_SUCCESS;
+}
+
+_Use_decl_annotations_ // <= APC_LEVEL
+NTSTATUS CODE_SEG_PAGE
+SlotExtension::SetVoltage(SDPORT_BUS_VOLTAGE voltage)
+{
+    // Similar sample code: SdhcSetVoltage
+    PAGED_CODE();
+
+    SdRegVoltage vdd1Voltage;
+    switch (voltage)
+    {
+    case SdBusVoltage33:
+        vdd1Voltage = SdRegVoltage3_3;
+        break;
+
+    case SdBusVoltage30:
+        vdd1Voltage = SdRegVoltage3_0;
+        break;
+
+    case SdBusVoltage18:
+        vdd1Voltage = SdRegVoltage1_8;
+        break;
+
+    case SdBusVoltageOff:
+        vdd1Voltage = SdRegVoltageNone;
+        break;
+
+    default:
+        LogError("SetVoltage-BadVoltage",
+            TraceLoggingUInt32(voltage, "Voltage"));
+        return STATUS_NOT_SUPPORTED;
+    }
+
+    SdRegPowerControl powerControl(READ_REGISTER_UCHAR(&m_registers->PowerControl.U8));
+
+    if (powerControl.Vdd1Power)
+    {
+        // Turn off power.
+        for (unsigned i = 0;; i += 1)
+        {
+            powerControl.Vdd1Power = false;
+            WRITE_REGISTER_UCHAR(&m_registers->PowerControl.U8, powerControl.U8);
+
+            powerControl = SdRegPowerControl(READ_REGISTER_UCHAR(&m_registers->PowerControl.U8));
+            if (!powerControl.Vdd1Power)
+            {
+                break;
+            }
+
+            if (i == RetryMaxCount)
+            {
+                LogError("SetVoltage-Timeout1",
+                    TraceLoggingUInt32(voltage, "Voltage"));
+                return STATUS_IO_TIMEOUT;
+            }
+
+            SdPortWait(RetryWaitMicroseconds);
+        }
+    }
+
+    if (voltage != SdBusVoltageOff)
+    {
+        // Set new voltage.
+        powerControl.Vdd1Voltage = vdd1Voltage;
+        WRITE_REGISTER_UCHAR(&m_registers->PowerControl.U8, powerControl.U8);
+
+        // Turn on power at new voltage.
+        for (unsigned i = 0;; i += 1)
+        {
+            powerControl.Vdd1Voltage = vdd1Voltage;
+            powerControl.Vdd1Power = true;
+            WRITE_REGISTER_UCHAR(&m_registers->PowerControl.U8, powerControl.U8);
+
+            powerControl = SdRegPowerControl(READ_REGISTER_UCHAR(&m_registers->PowerControl.U8));
+            if (powerControl.Vdd1Power &&
+                powerControl.Vdd1Voltage == vdd1Voltage)
+            {
+                break;
+            }
+
+            if (i == RetryMaxCount)
+            {
+                LogError("SetVoltage-Timeout2",
+                    TraceLoggingUInt32(voltage, "Voltage"));
+                return STATUS_IO_TIMEOUT;
+            }
+
+            SdPortWait(RetryWaitMicroseconds);
+        }
+    }
+
+    LogInfo("SetVoltage",
+        TraceLoggingUInt32(voltage, "Voltage"),
+        TraceLoggingHexInt8(READ_REGISTER_UCHAR(&m_registers->PowerControl.U8), "PowerControl"));
+    return STATUS_SUCCESS;
+}
+
+_Use_decl_annotations_ // <= APC_LEVEL
+NTSTATUS CODE_SEG_PAGE
+SlotExtension::SetBusWidth(SDPORT_BUS_WIDTH busWidth)
+{
+    // Similar sample code: SdhcSetBusWidth
+    PAGED_CODE();
+
+    SdRegHostControl1 hostControl1(READ_REGISTER_UCHAR(&m_registers->HostControl1.U8));
+    switch (busWidth)
+    {
+    case SdBusWidthUndefined:
+    case SdBusWidth1Bit:
+        hostControl1.DataTransferWidth4 = false;
+        hostControl1.DataTransferWidth8 = false;
+        break;
+    case SdBusWidth4Bit:
+        hostControl1.DataTransferWidth4 = true;
+        hostControl1.DataTransferWidth8 = false;
+        break;
+    case SdBusWidth8Bit:
+        hostControl1.DataTransferWidth4 = false;
+        hostControl1.DataTransferWidth8 = true;
+        break;
+    default:
+        LogError("SetBusWidth-BadWidth",
+            TraceLoggingUInt32(busWidth, "BusWidth"));
+        return STATUS_NOT_SUPPORTED;
+    }
+
+    WRITE_REGISTER_UCHAR(&m_registers->HostControl1.U8, hostControl1.U8);
+
+    LogInfo("SetBusWidth",
+        TraceLoggingUInt32(busWidth, "BusWidth"),
+        TraceLoggingHexInt8(READ_REGISTER_UCHAR(&m_registers->HostControl1.U8), "HostControl1"));
+    return STATUS_SUCCESS;
+}
+
+_Use_decl_annotations_ // <= APC_LEVEL
+NTSTATUS CODE_SEG_PAGE
+SlotExtension::SetBusSpeed(SDPORT_BUS_SPEED busSpeed)
+{
+    // Similar sample code: SdhcSetSpeed
+    PAGED_CODE();
+
+    SdRegHostControl1 hostControl1(READ_REGISTER_UCHAR(&m_registers->HostControl1.U8));
+    SdRegHostControl2 hostControl2(READ_REGISTER_USHORT(&m_registers->HostControl2.U16));
+
+    switch (busSpeed)
+    {
+    case SdBusSpeedNormal:
+    case SdBusSpeedHigh:
+        hostControl1.HighSpeedEnable = busSpeed == SdBusSpeedHigh;
+        break;
+    case SdBusSpeedSDR12:
+        hostControl2.UhsModeSelect = SdRegUhsSDR12;
+        break;
+    case SdBusSpeedSDR25:
+        hostControl2.UhsModeSelect = SdRegUhsSDR25;
+        break;
+    case SdBusSpeedSDR50:
+        hostControl2.UhsModeSelect = SdRegUhsSDR50;
+        break;
+    case SdBusSpeedDDR50:
+        hostControl2.UhsModeSelect = SdRegUhsDDR50;
+        break;
+    case SdBusSpeedSDR104:
+        hostControl2.UhsModeSelect = SdRegUhsSDR104;
+        break;
+    default:
+        LogError("SetBusSpeed-BadSpeed",
+            TraceLoggingUInt32(busSpeed, "BusSpeed"));
+        return STATUS_NOT_SUPPORTED;
+    }
+
+    SdRegClockControl clockControl(READ_REGISTER_USHORT(&m_registers->ClockControl.U16));
+    clockControl.SdClockEnable = false;
+    WRITE_REGISTER_USHORT(&m_registers->ClockControl.U16, clockControl.U16);
+    SdPortWait(ClockWaitMicroseconds);
+
+    WRITE_REGISTER_UCHAR(&m_registers->HostControl1.U8, hostControl1.U8);
+    WRITE_REGISTER_USHORT(&m_registers->HostControl2.U16, hostControl2.U16);
+
+    clockControl.SdClockEnable = true;
+    WRITE_REGISTER_USHORT(&m_registers->ClockControl.U16, clockControl.U16);
+    SdPortWait(ClockWaitMicroseconds);
+
+    LogInfo("SetBusSpeed",
+        TraceLoggingUInt32(busSpeed, "BusSpeed"),
+        TraceLoggingHexInt8(READ_REGISTER_UCHAR(&m_registers->HostControl1.U8), "HostControl1"),
+        TraceLoggingHexInt16(READ_REGISTER_USHORT(&m_registers->HostControl2.U16), "HostControl2"));
+    return STATUS_SUCCESS;
+}
+
+_Use_decl_annotations_ // <= APC_LEVEL
+NTSTATUS CODE_SEG_PAGE
+SlotExtension::SetSignalingVoltage(SDPORT_SIGNALING_VOLTAGE signalingVoltage)
+{
+    // Similar sample code: SdhcSetSignaling
+    PAGED_CODE();
+
+    bool signaling1_8;
+
+    switch (signalingVoltage)
+    {
+    case SdSignalingVoltage33:
+        signaling1_8 = false;
+        break;
+    case SdSignalingVoltage18:
+        signaling1_8 = true;
+        break;
+    default:
+        LogError("SetSignalingVoltage-BadVoltage",
+            TraceLoggingUInt32(signalingVoltage, "Voltage"));
+        return STATUS_NOT_SUPPORTED;
+    }
+
+    SdRegClockControl clockControl(0);
+    SdRegPresentState presentState(0);
+
+    // Stop clock.
+    clockControl.U16 = READ_REGISTER_USHORT(&m_registers->ClockControl.U16);
+    clockControl.SdClockEnable = false;
+    WRITE_REGISTER_USHORT(&m_registers->ClockControl.U16, clockControl.U16);
+    SdPortWait(ClockWaitMicroseconds);
+
+    // Verify DAT[3:0] == 0000.
+    presentState.U32 = READ_REGISTER_ULONG(&m_registers->PresentState.U32);
+    if (presentState.SdDatSignalLevel != 0)
+    {
+        LogError("SetSignalingVoltage-DatNotLow",
+            TraceLoggingUInt32(signalingVoltage, "Voltage"),
+            TraceLoggingHexInt32(presentState.U32, "PresentState"));
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    // BRCME88C: Configure voltage regulator.
+    bool const oldRegulatorVoltage1_8 = m_regulatorVoltage1_8;
+    if (signaling1_8 != m_regulatorVoltage1_8)
+    {
+        NTSTATUS status = SetRegulatorVoltage1_8(signaling1_8);
+        if (!NT_SUCCESS(status))
+        {
+            LogError("SetSignalingVoltage-SetGpio4",
+                TraceLoggingUInt32(signalingVoltage, "Voltage"),
+                TraceLoggingNTStatus(status));
+            return status;
+        }
+    }
+
+    SdRegHostControl2 hostControl2(READ_REGISTER_USHORT(&m_registers->HostControl2.U16));
+
+    hostControl2.Signaling1_8 = signaling1_8;
+    WRITE_REGISTER_USHORT(&m_registers->HostControl2.U16, hostControl2.U16);
+    SdPortWait(SignallingWaitMicroseconds);
+
+    hostControl2.U16 = READ_REGISTER_USHORT(&m_registers->HostControl2.U16);
+    if (hostControl2.Signaling1_8 != (signalingVoltage == SdSignalingVoltage18))
+    {
+        LogError("SetSignalingVoltage-NotLatched",
+            TraceLoggingUInt32(signalingVoltage, "Voltage"),
+            TraceLoggingHexInt16(hostControl2.U16, "HostControl2"));
+
+        // BRCME88C: Restore voltage regulator to original state.
+        if (oldRegulatorVoltage1_8 != m_regulatorVoltage1_8)
+        {
+            SetRegulatorVoltage1_8(oldRegulatorVoltage1_8);
+        }
+
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    clockControl.U16 = READ_REGISTER_USHORT(&m_registers->ClockControl.U16);
+    clockControl.SdClockEnable = true;
+    WRITE_REGISTER_USHORT(&m_registers->ClockControl.U16, clockControl.U16);
+    SdPortWait(ClockWaitMicroseconds);
+
+    presentState.U32 = READ_REGISTER_ULONG(&m_registers->PresentState.U32);
+    if (presentState.SdDatSignalLevel != 0x0F)
+    {
+        LogError("SetSignalingVoltage-DatNotHigh",
+            TraceLoggingUInt32(signalingVoltage, "Voltage"),
+            TraceLoggingHexInt32(presentState.U32, "PresentState"));
+
+        // BRCME88C: Restore voltage regulator to original state.
+        if (oldRegulatorVoltage1_8 != m_regulatorVoltage1_8)
+        {
+            SetRegulatorVoltage1_8(oldRegulatorVoltage1_8);
+        }
+
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    LogInfo("SetSignalingVoltage",
+        TraceLoggingUInt32(signalingVoltage, "Voltage"),
+        TraceLoggingHexInt16(READ_REGISTER_USHORT(&m_registers->HostControl2.U16), "HostControl2"));
+    return STATUS_SUCCESS;
+}
+
+_Use_decl_annotations_ // <= APC_LEVEL
+NTSTATUS CODE_SEG_PAGE
+SlotExtension::SetDriverType(SDPORT_DRIVER_TYPE driverType)
+{
+    PAGED_CODE();
+
+    SdRegHostControl2 hostControl2(READ_REGISTER_USHORT(&m_registers->HostControl2.U16));
+
+    switch (driverType)
+    {
+    case SdDriverTypeB:
+        hostControl2.DriverStrength = SdRegDriverStrengthB;
+        break;
+    case SdDriverTypeA:
+        hostControl2.DriverStrength = SdRegDriverStrengthA;
+        break;
+    case SdDriverTypeC:
+        hostControl2.DriverStrength = SdRegDriverStrengthC;
+        break;
+    case SdDriverTypeD:
+        hostControl2.DriverStrength = SdRegDriverStrengthD;
+        break;
+    default:
+        LogError("SetDriverType-BadType",
+            TraceLoggingUInt32(driverType, "DriverType"));
+        return STATUS_NOT_SUPPORTED;
+    }
+
+    WRITE_REGISTER_USHORT(&m_registers->HostControl2.U16, hostControl2.U16);
+
+    LogInfo("SetDriverType",
+        TraceLoggingUInt32(driverType, "DriverType"),
+        TraceLoggingHexInt16(READ_REGISTER_USHORT(&m_registers->HostControl2.U16), "HostControl2"));
+    return STATUS_SUCCESS;
+}
+
+_Use_decl_annotations_ // <= APC_LEVEL
+NTSTATUS CODE_SEG_PAGE
+SlotExtension::SetPresetValue(bool enabled)
+{
+    PAGED_CODE();
+
+    SdRegHostControl2 hostControl2(READ_REGISTER_USHORT(&m_registers->HostControl2.U16));
+    hostControl2.PresetValueEnable = enabled;
+    WRITE_REGISTER_USHORT(&m_registers->HostControl2.U16, hostControl2.U16);
+
+    LogInfo("SetPresetValue",
+        TraceLoggingBoolean(enabled, "Enabled"),
+        TraceLoggingHexInt16(READ_REGISTER_USHORT(&m_registers->HostControl2.U16), "HostControl2"));
+    return STATUS_SUCCESS;
+}
+
+_Use_decl_annotations_ // <= APC_LEVEL
+NTSTATUS CODE_SEG_PAGE
+SlotExtension::SetBlockGapInterrupt(bool enabled)
+{
+    // Similar sample code: SdhcEnableBlockGapInterrupt
+    PAGED_CODE();
+
+    SdRegBlockGapControl blockGapControl(READ_REGISTER_UCHAR(&m_registers->BlockGapControl.U8));
+    blockGapControl.InterruptAtBlockGap = enabled;
+    WRITE_REGISTER_UCHAR(&m_registers->BlockGapControl.U8, blockGapControl.U8);
+
+    LogInfo("SetBlockGapInterrupt",
+        TraceLoggingBoolean(enabled, "Enabled"),
+        TraceLoggingHexInt8(READ_REGISTER_UCHAR(&m_registers->BlockGapControl.U8), "BlockGapControl"));
+    return STATUS_SUCCESS;
+}
+
+_Use_decl_annotations_ // <= APC_LEVEL
+NTSTATUS CODE_SEG_PAGE
+SlotExtension::ExecuteTuning()
+{
+    PAGED_CODE();
+
+    LogWarning("ExecuteTuning");
+    return STATUS_SUCCESS; // TUNE-TODO
+}

--- a/drivers/sd/bcm2711/brcme88c/SlotExtension.h
+++ b/drivers/sd/bcm2711/brcme88c/SlotExtension.h
@@ -193,12 +193,19 @@ private:
 
 private:
 
-    volatile SdRegisters* m_registers;
+    enum Magic : UINT16
+    {
+        MagicPreInitialize = 0,
+        MagicValid = 0xE88C,
+        MagicPostCleanup = 0xDEAD,
+    };
+
+    volatile SdRegisters* m_registers; // Should only be accessed via READ_REGISTER/WRITE_REGISTER.
     MDL* m_pDmaDataMdl;
     MDL* m_pDmaDescriptorMdl;
     UINT32 m_iDmaEndDescriptor; // The index of the descriptor where End == true.
     SDPORT_TRANSFER_DIRECTION m_dmaInProgress;
-    UINT16 m_magic;
+    Magic m_magic;
     bool m_crashDumpMode;
     bool m_regulatorVoltage1_8;
     WORK_QUEUE_ITEM m_rpiqWorkItem;

--- a/drivers/sd/bcm2711/brcme88c/SlotExtension.h
+++ b/drivers/sd/bcm2711/brcme88c/SlotExtension.h
@@ -1,0 +1,185 @@
+/*
+Copyright 2021 Douglas Cook
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#pragma once
+#include "SdRegisters.h"
+
+class SlotExtension
+{
+    static unsigned const GpioExpanderOffset = 128;
+    static unsigned const SignalingVoltageGpio = 4 + GpioExpanderOffset;
+
+    static UINT8 const MaximumOutstandingRequests = 1;
+
+    static auto const RetryMaxCount = 100u;
+    static auto const RetryWaitMicroseconds = 1000u;
+
+    static auto const ClockWaitMicroseconds = 10u * 1000u;
+    static auto const SignallingWaitMicroseconds = 5u * 1000u;
+
+    // 14 = slowest possible timeout clock.
+    static auto const DataTimeoutCounterValue = 14u;
+
+public:
+
+    _IRQL_requires_max_(PASSIVE_LEVEL)
+    NTSTATUS CODE_SEG_PAGE
+    SlotInitialize(
+        _In_ PHYSICAL_ADDRESS physicalBase,
+        _In_ void* virtualBase,
+        _In_ ULONG length,
+        _In_ BOOLEAN crashdumpMode);
+
+    _IRQL_requires_max_(PASSIVE_LEVEL)
+    void CODE_SEG_PAGE
+    SlotGetSlotCapabilities(_Out_ SDPORT_CAPABILITIES* capabilities);
+
+    _IRQL_requires_max_(APC_LEVEL)
+    NTSTATUS CODE_SEG_PAGE
+    SlotIssueBusOperation(_In_ SDPORT_BUS_OPERATION const& busOperation);
+
+    _IRQL_requires_max_(PASSIVE_LEVEL)
+    BOOLEAN CODE_SEG_PAGE
+    SlotGetCardDetectState();
+
+    _IRQL_requires_max_(DISPATCH_LEVEL)
+    BOOLEAN CODE_SEG_TEXT
+    SlotGetWriteProtectState();
+
+    _IRQL_requires_max_(HIGH_LEVEL)
+    BOOLEAN CODE_SEG_TEXT
+    SlotInterrupt(
+        _Out_ ULONG* events,
+        _Out_ ULONG* errors,
+        _Out_ BOOLEAN* notifyCardChange,
+        _Out_ BOOLEAN* notifySdioInterrupt,
+        _Out_ BOOLEAN* notifyTuning);
+
+    _IRQL_requires_(DISPATCH_LEVEL)
+    NTSTATUS CODE_SEG_TEXT
+    SlotIssueRequest(_Inout_ SDPORT_REQUEST* request);
+
+    _IRQL_requires_max_(DISPATCH_LEVEL)
+    void CODE_SEG_TEXT
+    SlotGetResponse(
+        _In_ SDPORT_COMMAND const& command,
+        _Inout_bytecap_c_(16) void* responseBuffer);
+
+    _IRQL_requires_max_(HIGH_LEVEL)
+    void CODE_SEG_TEXT
+    SlotToggleEvents(
+        _In_ ULONG eventMask,
+        _In_ BOOLEAN enable);
+
+    _IRQL_requires_max_(HIGH_LEVEL)
+    void CODE_SEG_TEXT
+    SlotClearEvents(_In_ ULONG eventMask);
+
+    _IRQL_requires_(DISPATCH_LEVEL)
+    void CODE_SEG_TEXT
+    SlotRequestDpc(
+        _Inout_ SDPORT_REQUEST* request,
+        _In_ ULONG events,
+        _In_ ULONG errors);
+
+    _IRQL_requires_max_(DISPATCH_LEVEL)
+    void CODE_SEG_TEXT
+    SlotSaveContext();
+
+    _IRQL_requires_max_(DISPATCH_LEVEL)
+    void CODE_SEG_TEXT
+    SlotRestoreContext();
+
+private:
+
+    _IRQL_requires_max_(APC_LEVEL)
+    NTSTATUS CODE_SEG_PAGE
+    SetRegulatorVoltage1_8(bool regulatorVoltage1_8);
+
+    _IRQL_requires_max_(HIGH_LEVEL)
+    void CODE_SEG_TEXT
+    AcknowledgeInterrupts(SdRegNormalInterrupts interruptMask);
+
+    _IRQL_requires_(DISPATCH_LEVEL)
+    NTSTATUS CODE_SEG_TEXT
+    SendCommand(_Inout_ SDPORT_REQUEST* request);
+
+    _IRQL_requires_(DISPATCH_LEVEL)
+    NTSTATUS CODE_SEG_TEXT
+    StartPioTransfer(_Inout_ SDPORT_REQUEST* request);
+
+    _IRQL_requires_(DISPATCH_LEVEL)
+    NTSTATUS CODE_SEG_TEXT
+    StartDmaTransfer(_In_ SDPORT_REQUEST* request);
+
+    _IRQL_requires_max_(APC_LEVEL)
+    NTSTATUS CODE_SEG_PAGE
+    ResetHw();
+
+    _IRQL_requires_max_(APC_LEVEL)
+    NTSTATUS CODE_SEG_PAGE
+    ResetHost(SDPORT_RESET_TYPE resetType);
+
+    _IRQL_requires_max_(APC_LEVEL)
+    NTSTATUS CODE_SEG_PAGE
+    SetClock(ULONG frequencyKhz);
+
+    _IRQL_requires_max_(APC_LEVEL)
+    NTSTATUS CODE_SEG_PAGE
+    SetVoltage(SDPORT_BUS_VOLTAGE voltage);
+
+    _IRQL_requires_max_(APC_LEVEL)
+    NTSTATUS CODE_SEG_PAGE
+    SetBusWidth(SDPORT_BUS_WIDTH busWidth);
+
+    _IRQL_requires_max_(APC_LEVEL)
+    NTSTATUS CODE_SEG_PAGE
+    SetBusSpeed(SDPORT_BUS_SPEED busSpeed);
+
+    _IRQL_requires_max_(APC_LEVEL)
+    NTSTATUS CODE_SEG_PAGE
+    SetSignalingVoltage(SDPORT_SIGNALING_VOLTAGE signalingVoltage);
+
+    _IRQL_requires_max_(APC_LEVEL)
+    NTSTATUS CODE_SEG_PAGE
+    SetDriverType(SDPORT_DRIVER_TYPE driverType);
+
+    _IRQL_requires_max_(APC_LEVEL)
+    NTSTATUS CODE_SEG_PAGE
+    SetPresetValue(bool enabled);
+
+    _IRQL_requires_max_(APC_LEVEL)
+    NTSTATUS CODE_SEG_PAGE
+    SetBlockGapInterrupt(bool enabled);
+
+    _IRQL_requires_max_(APC_LEVEL)
+    NTSTATUS CODE_SEG_PAGE
+    ExecuteTuning();
+
+private:
+
+    volatile SdRegisters* m_registers;
+    PHYSICAL_ADDRESS m_physicalBase;
+    bool m_crashDumpMode;
+    bool m_regulatorVoltage1_8;
+    SDPORT_CAPABILITIES m_capabilities;
+};

--- a/drivers/sd/bcm2711/brcme88c/SlotExtension.h
+++ b/drivers/sd/bcm2711/brcme88c/SlotExtension.h
@@ -111,9 +111,19 @@ public:
 
 private:
 
-    _IRQL_requires_max_(APC_LEVEL)
+    _IRQL_requires_(PASSIVE_LEVEL)
     NTSTATUS CODE_SEG_PAGE
     SetRegulatorVoltage1_8(bool regulatorVoltage1_8);
+
+    _IRQL_requires_max_(PASSIVE_LEVEL)
+    _IRQL_requires_same_
+    _Function_class_(WORKER_THREAD_ROUTINE)
+    static void CODE_SEG_PAGE
+    InvokeSetRegulatorVoltageWorker(void* parameter);
+
+    _IRQL_requires_max_(APC_LEVEL)
+    NTSTATUS CODE_SEG_PAGE
+    InvokeSetRegulatorVoltage1_8(bool regulatorVoltage1_8);
 
     _IRQL_requires_max_(HIGH_LEVEL)
     void CODE_SEG_TEXT
@@ -181,5 +191,6 @@ private:
     PHYSICAL_ADDRESS m_physicalBase;
     bool m_crashDumpMode;
     bool m_regulatorVoltage1_8;
+    WORK_QUEUE_ITEM m_rpiqWorkItem;
     SDPORT_CAPABILITIES m_capabilities;
 };

--- a/drivers/sd/bcm2711/brcme88c/driver.cpp
+++ b/drivers/sd/bcm2711/brcme88c/driver.cpp
@@ -84,7 +84,8 @@ DriverCleanupNormal(
     SD_MINIPORT* miniport)
 {
     PAGED_CODE();
-    UNREFERENCED_PARAMETER(miniport);
+
+    DriverCleanupCrashdump(miniport);
 
     LogInfo("DriverCleanup");
     DriverExitNormal();
@@ -96,7 +97,16 @@ DriverCleanupCrashdump(
     SD_MINIPORT* miniport)
 {
     PAGED_CODE();
-    UNREFERENCED_PARAMETER(miniport);
+
+    for (UCHAR i = 0; i != miniport->SlotCount; i++)
+    {
+        auto pSlot = miniport->SlotExtensionList[i];
+        if (pSlot != NULL)
+        {
+            auto pSlotExtension = reinterpret_cast<SlotExtension*>(pSlot->PrivateExtension);
+            pSlotExtension->SlotCleanup();
+        }
+    }
 }
 
 _Use_decl_annotations_ extern "C" // = PASSIVE_LEVEL
@@ -207,10 +217,10 @@ DriverPoFxPowerControlCallback(
     SD_MINIPORT* miniport,
     GUID const* powerControlCode,
     void* inputBuffer,
-    size_t inputBufferSize,
+    SIZE_T inputBufferSize,
     void* outputBuffer,
-    size_t outputBufferSize,
-    size_t* bytesReturned)
+    SIZE_T outputBufferSize,
+    SIZE_T* bytesReturned)
 {
     UNREFERENCED_PARAMETER(miniport);
     UNREFERENCED_PARAMETER(powerControlCode);

--- a/drivers/sd/bcm2711/brcme88c/driver.cpp
+++ b/drivers/sd/bcm2711/brcme88c/driver.cpp
@@ -245,7 +245,7 @@ DriverRpiqIsAvailable()
     return g_rpiqFileObject != nullptr;
 }
 
-_Use_decl_annotations_ // <= APC_LEVEL
+_Use_decl_annotations_ // = PASSIVE_LEVEL
 NTSTATUS CODE_SEG_PAGE
 DriverRpiqProperty(
     _Inout_ MAILBOX_HEADER* item)
@@ -261,7 +261,7 @@ DriverRpiqProperty(
     else
     {
         KEVENT event;
-        KeInitializeEvent(&event, NotificationEvent, FALSE);
+        KeInitializeEvent(&event, NotificationEvent, false);
 
         DEVICE_OBJECT* deviceObject = IoGetRelatedDeviceObject(g_rpiqFileObject);
         IO_STATUS_BLOCK statusBlock = {};

--- a/drivers/sd/bcm2711/brcme88c/driver.cpp
+++ b/drivers/sd/bcm2711/brcme88c/driver.cpp
@@ -1,0 +1,442 @@
+/*
+Copyright 2021 Douglas Cook
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "precomp.h"
+#include "driver.h"
+#include "SlotExtension.h"
+#include "trace.h"
+
+// Global variables
+
+// BRCME88C: RPIQ driver handle for controlling regulator voltage.
+static FILE_OBJECT* g_rpiqFileObject;
+
+TRACELOGGING_DEFINE_PROVIDER(
+    g_trace,
+    "SDHostBRCME88C",
+    // *SDHostBRCME88C = {f2782ab9-d1a5-5f95-240a-ac933a6937e2}
+    (0xf2782ab9, 0xd1a5, 0x5f95, 0x24, 0x0a, 0xac, 0x93, 0x3a, 0x69, 0x37, 0xe2));
+
+// Forward declarations to ensure the SDPORT-defined prototypes match our definitions.
+
+extern "C" DRIVER_INITIALIZE DriverEntry;
+static SDPORT_CLEANUP DriverCleanupNormal;
+static SDPORT_CLEANUP DriverCleanupCrashdump;
+static SDPORT_GET_SLOT_COUNT DriverGetSlotCount;
+static SDPORT_PO_FX_POWER_CONTROL_CALLBACK DriverPoFxPowerControlCallback;
+
+static SDPORT_INITIALIZE SlotInitialize;
+static SDPORT_GET_SLOT_CAPABILITIES SlotGetSlotCapabilities;
+static SDPORT_ISSUE_BUS_OPERATION SlotIssueBusOperation;
+static SDPORT_GET_CARD_DETECT_STATE SlotGetCardDetectState;
+static SDPORT_GET_WRITE_PROTECT_STATE SlotGetWriteProtectState;
+static SDPORT_INTERRUPT SlotInterrupt;
+static SDPORT_ISSUE_REQUEST SlotIssueRequest;
+static SDPORT_GET_RESPONSE SlotGetResponse;
+static SDPORT_TOGGLE_EVENTS SlotToggleEvents;
+static SDPORT_CLEAR_EVENTS SlotClearEvents;
+static SDPORT_REQUEST_DPC SlotRequestDpc;
+static SDPORT_SAVE_CONTEXT SlotSaveContext;
+static SDPORT_RESTORE_CONTEXT SlotRestoreContext;
+
+// Driver-global functions
+
+static
+void CODE_SEG_PAGE
+DriverExitNormal()
+{
+    PAGED_CODE();
+
+    // This is the code that should run for normal driver exit but
+    // NOT for crashdump-mode driver exit.
+
+    if (g_rpiqFileObject != nullptr)
+    {
+        ObDereferenceObject(g_rpiqFileObject);
+        g_rpiqFileObject = nullptr;
+    }
+
+    TraceLoggingUnregister(g_trace);
+}
+
+_Use_decl_annotations_ static // = PASSIVE_LEVEL
+void CODE_SEG_PAGE
+DriverCleanupNormal(
+    SD_MINIPORT* miniport)
+{
+    PAGED_CODE();
+    UNREFERENCED_PARAMETER(miniport);
+
+    LogInfo("DriverCleanup");
+    DriverExitNormal();
+}
+
+_Use_decl_annotations_ static // = PASSIVE_LEVEL
+void CODE_SEG_PAGE
+DriverCleanupCrashdump(
+    SD_MINIPORT* miniport)
+{
+    PAGED_CODE();
+    UNREFERENCED_PARAMETER(miniport);
+}
+
+_Use_decl_annotations_ extern "C" // = PASSIVE_LEVEL
+NTSTATUS CODE_SEG_INIT
+DriverEntry(
+    DRIVER_OBJECT* driverObject,
+    UNICODE_STRING* registryPath)
+{
+    PAGED_CODE();
+
+    NTSTATUS status;
+
+    // If DriverEntry is called with higher IRQL, assume crash-dump mode.
+    bool const crashDumpMode = KeGetCurrentIrql() != PASSIVE_LEVEL;
+
+    // Logging and regulator control are unavailable in crash-dump mode.
+    if (!crashDumpMode)
+    {
+        // Activate ETW tracing.
+        TraceLoggingRegister(g_trace);
+
+        // BRCME88C: Try to access the RPIQ driver so we can control regulator voltage.
+        ULONG const RpiqDesiredAccess = GENERIC_READ | GENERIC_WRITE;
+        DECLARE_CONST_UNICODE_STRING(rpiqDeviceName, RPIQ_SYMBOLIC_NAME);
+        OBJECT_ATTRIBUTES attributes;
+        InitializeObjectAttributes(
+            &attributes,
+            const_cast<UNICODE_STRING*>(&rpiqDeviceName),
+            OBJ_KERNEL_HANDLE,
+            NULL,
+            NULL);
+        HANDLE rpiqHandle = nullptr;
+        IO_STATUS_BLOCK statusBlock;
+        status = ZwCreateFile(
+            &rpiqHandle,
+            RpiqDesiredAccess,
+            &attributes,
+            &statusBlock,
+            nullptr,
+            FILE_ATTRIBUTE_NORMAL,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            FILE_OPEN,
+            FILE_NON_DIRECTORY_FILE,
+            nullptr,
+            0);
+        if (!NT_SUCCESS(status))
+        {
+            LogWarning("DriverEntry-RPIQ-CreateFileError", TraceLoggingNTStatus(status));
+        }
+        else
+        {
+            status = ObReferenceObjectByHandle(
+                rpiqHandle,
+                RpiqDesiredAccess,
+                *IoFileObjectType,
+                KernelMode,
+                (void**)&g_rpiqFileObject,
+                nullptr);
+            ZwClose(rpiqHandle);
+            if (!NT_SUCCESS(status))
+            {
+                LogWarning("DriverEntry-RPIQ-ReferenceError", TraceLoggingNTStatus(status));
+            }
+        }
+    }
+
+    SDPORT_INITIALIZATION_DATA initializationData;
+    memset(&initializationData, 0, sizeof(initializationData));
+
+    initializationData.StructureSize = sizeof(initializationData);
+    initializationData.GetSlotCount = DriverGetSlotCount;
+    initializationData.GetSlotCapabilities = SlotGetSlotCapabilities;
+    initializationData.Interrupt = SlotInterrupt;
+    initializationData.IssueRequest = SlotIssueRequest;
+    initializationData.GetResponse = SlotGetResponse;
+    initializationData.RequestDpc = SlotRequestDpc;
+    initializationData.ToggleEvents = SlotToggleEvents;
+    initializationData.ClearEvents = SlotClearEvents;
+    initializationData.SaveContext = SlotSaveContext;
+    initializationData.RestoreContext = SlotRestoreContext;
+    initializationData.Initialize = SlotInitialize;
+    initializationData.IssueBusOperation = SlotIssueBusOperation;
+    initializationData.GetCardDetectState = SlotGetCardDetectState;
+    initializationData.GetWriteProtectState = SlotGetWriteProtectState;
+    initializationData.PowerControlCallback = DriverPoFxPowerControlCallback;
+    initializationData.Cleanup = crashDumpMode ? DriverCleanupCrashdump : DriverCleanupNormal;
+    initializationData.PrivateExtensionSize = sizeof(SlotExtension);
+    initializationData.CrashdumpSupported = true;
+
+    status = SdPortInitialize(driverObject, registryPath, &initializationData);
+
+    if (NT_SUCCESS(status))
+    {
+        LogInfo("DriverEntry");
+    }
+    else if (!crashDumpMode)
+    {
+        LogError("DriverEntry-SdPortInitializeError", TraceLoggingNTStatus(status));
+        DriverExitNormal();
+    }
+
+    return status;
+}
+
+_Use_decl_annotations_ static // <= DISPATCH_LEVEL
+NTSTATUS CODE_SEG_TEXT
+DriverPoFxPowerControlCallback(
+    SD_MINIPORT* miniport,
+    GUID const* powerControlCode,
+    void* inputBuffer,
+    size_t inputBufferSize,
+    void* outputBuffer,
+    size_t outputBufferSize,
+    size_t* bytesReturned)
+{
+    UNREFERENCED_PARAMETER(miniport);
+    UNREFERENCED_PARAMETER(powerControlCode);
+    UNREFERENCED_PARAMETER(inputBuffer);
+    UNREFERENCED_PARAMETER(inputBufferSize);
+    UNREFERENCED_PARAMETER(outputBuffer);
+    UNREFERENCED_PARAMETER(outputBufferSize);
+    UNREFERENCED_PARAMETER(bytesReturned);
+
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+_Use_decl_annotations_ static // = PASSIVE_LEVEL
+NTSTATUS CODE_SEG_PAGE
+DriverGetSlotCount(
+    SD_MINIPORT* miniport,
+    UCHAR* slotCount)
+{
+    PAGED_CODE();
+    UNREFERENCED_PARAMETER(miniport);
+
+    // BRCME88C: Hardcoded to 1.
+    *slotCount = 1;
+    return STATUS_SUCCESS;
+}
+
+_Use_decl_annotations_ // <= APC_LEVEL
+bool CODE_SEG_PAGE
+DriverRpiqIsAvailable()
+{
+    PAGED_CODE();
+    return g_rpiqFileObject != nullptr;
+}
+
+_Use_decl_annotations_ // <= APC_LEVEL
+NTSTATUS CODE_SEG_PAGE
+DriverRpiqProperty(
+    _Inout_ MAILBOX_HEADER* item)
+{
+    PAGED_CODE();
+
+    NTSTATUS status;
+
+    if (g_rpiqFileObject == nullptr)
+    {
+        status = STATUS_NOT_FOUND;
+    }
+    else
+    {
+        KEVENT event;
+        KeInitializeEvent(&event, NotificationEvent, FALSE);
+
+        DEVICE_OBJECT* deviceObject = IoGetRelatedDeviceObject(g_rpiqFileObject);
+        IO_STATUS_BLOCK statusBlock = {};
+        IRP* irp = IoBuildDeviceIoControlRequest(
+            IOCTL_MAILBOX_PROPERTY,
+            deviceObject,
+            item,
+            item->TotalBuffer,
+            item,
+            item->TotalBuffer,
+            false,
+            &event,
+            &statusBlock);
+        if (irp == nullptr)
+        {
+            status = STATUS_INSUFFICIENT_RESOURCES;
+        }
+        else
+        {
+            auto irpLocation = IoGetNextIrpStackLocation(irp);
+            irpLocation->FileObject = g_rpiqFileObject;
+
+            statusBlock.Status = STATUS_NOT_SUPPORTED;
+            status = IoCallDriver(deviceObject, irp);
+            if (status == STATUS_PENDING)
+            {
+                KeWaitForSingleObject(&event, Executive, KernelMode, false, nullptr);
+                status = statusBlock.Status;
+            }
+        }
+    }
+
+    return status;
+}
+
+// Per-slot functions forwarded to SlotExtension class
+
+_Use_decl_annotations_ static // = PASSIVE_LEVEL
+NTSTATUS CODE_SEG_PAGE
+SlotInitialize(
+    void* slotExtension,
+    PHYSICAL_ADDRESS physicalBase,
+    void* virtualBase,
+    ULONG length,
+    BOOLEAN crashdumpMode)
+{
+    PAGED_CODE();
+    return static_cast<SlotExtension*>(slotExtension)->
+        SlotInitialize(physicalBase, virtualBase, length, crashdumpMode);
+}
+
+_Use_decl_annotations_ static // = PASSIVE_LEVEL
+void CODE_SEG_PAGE
+SlotGetSlotCapabilities(
+    void* slotExtension,
+    SDPORT_CAPABILITIES* capabilities)
+{
+    PAGED_CODE();
+    return static_cast<SlotExtension*>(slotExtension)->
+        SlotGetSlotCapabilities(capabilities);
+}
+
+_Use_decl_annotations_ static // <= APC_LEVEL
+NTSTATUS CODE_SEG_PAGE
+SlotIssueBusOperation(
+    void* slotExtension,
+    SDPORT_BUS_OPERATION* busOperation)
+{
+    PAGED_CODE();
+    return static_cast<SlotExtension*>(slotExtension)->
+        SlotIssueBusOperation(*busOperation);
+}
+
+_Use_decl_annotations_ static // = PASSIVE_LEVEL
+BOOLEAN CODE_SEG_PAGE
+SlotGetCardDetectState(
+    void* slotExtension)
+{
+    PAGED_CODE();
+    return static_cast<SlotExtension*>(slotExtension)->
+        SlotGetCardDetectState();
+}
+
+_Use_decl_annotations_ static // <= DISPATCH_LEVEL (sdport.h declaration is WRONG)
+BOOLEAN CODE_SEG_TEXT
+SlotGetWriteProtectState(
+    void* slotExtension)
+{
+    return static_cast<SlotExtension*>(slotExtension)->
+        SlotGetWriteProtectState();
+}
+
+_Use_decl_annotations_ static // <= HIGH_LEVEL
+BOOLEAN CODE_SEG_TEXT
+SlotInterrupt(
+    void* slotExtension,
+    ULONG* events,
+    ULONG* errors,
+    BOOLEAN* notifyCardChange,
+    BOOLEAN* notifySdioInterrupt,
+    BOOLEAN* notifyTuning)
+{
+    return static_cast<SlotExtension*>(slotExtension)->
+        SlotInterrupt(events, errors, notifyCardChange, notifySdioInterrupt, notifyTuning);
+}
+
+_Use_decl_annotations_ static // = DISPATCH_LEVEL
+NTSTATUS CODE_SEG_TEXT
+SlotIssueRequest(
+    void* slotExtension,
+    SDPORT_REQUEST* request)
+{
+    return static_cast<SlotExtension*>(slotExtension)->
+        SlotIssueRequest(request);
+}
+
+_Use_decl_annotations_ static // <= DISPATCH_LEVEL
+void CODE_SEG_TEXT
+SlotGetResponse(
+    void* slotExtension,
+    SDPORT_COMMAND* command,
+    void* responseBuffer)
+{
+#pragma warning(suppress:6001) // SDPORT_GET_RESPONSE has incorrect SAL annotation.
+    return static_cast<SlotExtension*>(slotExtension)->
+        SlotGetResponse(*command, responseBuffer);
+}
+
+_Use_decl_annotations_ static // <= HIGH_LEVEL (?)
+void CODE_SEG_TEXT
+SlotToggleEvents(
+    void* slotExtension,
+    ULONG eventMask,
+    BOOLEAN enable)
+{
+    return static_cast<SlotExtension*>(slotExtension)->
+        SlotToggleEvents(eventMask, enable);
+}
+
+_Use_decl_annotations_ static // <= HIGH_LEVEL (?)
+void CODE_SEG_TEXT
+SlotClearEvents(
+    void* slotExtension,
+    ULONG eventMask)
+{
+    return static_cast<SlotExtension*>(slotExtension)->
+        SlotClearEvents(eventMask);
+}
+
+_Use_decl_annotations_ static // = DISPATCH_LEVEL
+void CODE_SEG_TEXT
+SlotRequestDpc(
+    void* slotExtension,
+    SDPORT_REQUEST* request,
+    ULONG events,
+    ULONG errors)
+{
+    return static_cast<SlotExtension*>(slotExtension)->
+        SlotRequestDpc(request, events, errors);
+}
+
+_Use_decl_annotations_ static // <= DISPATCH_LEVEL
+void CODE_SEG_TEXT
+SlotSaveContext(
+    void* slotExtension)
+{
+    return static_cast<SlotExtension*>(slotExtension)->
+        SlotSaveContext();
+}
+
+_Use_decl_annotations_ static // <= DISPATCH_LEVEL
+void CODE_SEG_TEXT
+SlotRestoreContext(
+    void* slotExtension)
+{
+    return static_cast<SlotExtension*>(slotExtension)->
+        SlotRestoreContext();
+}

--- a/drivers/sd/bcm2711/brcme88c/driver.h
+++ b/drivers/sd/bcm2711/brcme88c/driver.h
@@ -4,11 +4,12 @@ _IRQL_requires_max_(HIGH_LEVEL)
 __forceinline bool
 DriverShouldLogVerboseInfo()
 {
-    static UINT8 s_verboseInfoEventCount;
-    bool const shouldLog = s_verboseInfoEventCount != 100;
+    static UINT32 s_verboseInfoEventCount;
+    bool const shouldLog = s_verboseInfoEventCount < 100;
 
     // Not interlocked. A few extra events won't hurt anything.
     s_verboseInfoEventCount += shouldLog;
+
     return shouldLog;
 }
 
@@ -16,7 +17,7 @@ _IRQL_requires_max_(APC_LEVEL)
 bool CODE_SEG_PAGE
 DriverRpiqIsAvailable();
 
-_IRQL_requires_max_(APC_LEVEL)
+_IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS CODE_SEG_PAGE
 DriverRpiqProperty(
     _Inout_ MAILBOX_HEADER* item);

--- a/drivers/sd/bcm2711/brcme88c/driver.h
+++ b/drivers/sd/bcm2711/brcme88c/driver.h
@@ -1,0 +1,22 @@
+#pragma once
+
+_IRQL_requires_max_(HIGH_LEVEL)
+__forceinline bool
+DriverShouldLogVerboseInfo()
+{
+    static UINT8 s_verboseInfoEventCount;
+    bool const shouldLog = s_verboseInfoEventCount != 100;
+
+    // Not interlocked. A few extra events won't hurt anything.
+    s_verboseInfoEventCount += shouldLog;
+    return shouldLog;
+}
+
+_IRQL_requires_max_(APC_LEVEL)
+bool CODE_SEG_PAGE
+DriverRpiqIsAvailable();
+
+_IRQL_requires_max_(APC_LEVEL)
+NTSTATUS CODE_SEG_PAGE
+DriverRpiqProperty(
+    _Inout_ MAILBOX_HEADER* item);

--- a/drivers/sd/bcm2711/brcme88c/precomp.h
+++ b/drivers/sd/bcm2711/brcme88c/precomp.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <wdm.h>
+#include <TraceLoggingProvider.h>
+#include <evntrace.h>
+
+extern "C" {
+    #include <sdport.h>
+}
+
+#define BYTE UCHAR
+#include <rpiq.h>
+#undef BYTE
+
+#define CODE_SEG_INIT __declspec(code_seg("INIT"))
+#define CODE_SEG_PAGE __declspec(code_seg("PAGE"))
+#define CODE_SEG_TEXT __declspec(code_seg(".text"))

--- a/drivers/sd/bcm2711/brcme88c/trace.h
+++ b/drivers/sd/bcm2711/brcme88c/trace.h
@@ -1,0 +1,52 @@
+#pragma once
+
+/*
+ETW (TraceLogging) support:
+- ProviderId is EtwNameHash("SDHostBRCME88C") = f2782ab9-d1a5-5f95-240a-ac933a6937e2
+- Start trace: tracelog -start MyLoggerName -f MyLoggerFile.etl -guid *SDHostBRCME88C -level 4
+- Stop trace:  tracelog -stop MyLoggerName
+- View with your favorite ETW tool - tracefmt, traceview, tracerpt, etc.
+
+If you add -kd to the tracelog command line and run KD command "!wmitrace.dynamicprint 1",
+the events will be sent directly to KD.
+
+For boot tracing, use an autologger. For development only, the AutoLogger.reg file will enable
+an autologger that saves to c:\windows\system32\logfiles\wmi\SDHostBRCME88C.etl,
+collects at level Info (4), and sends events to KD in real-time.
+*/
+
+// Declare a global variable named g_trace that can be used with TraceLoggingWrite.
+TRACELOGGING_DECLARE_PROVIDER(g_trace);
+
+// All ETW events should have at least one keyword set.
+// Define a keyword that means "Log":
+#define DRIVER_KEYWORD_LOG 0x1
+
+// Macro to slightly simplify the use of TraceLoggingWrite.
+#define DRIVER_TRACE(eventName, level, keyword, ...) TraceLoggingWrite( \
+    g_trace, \
+    eventName, \
+    TraceLoggingLevel(level), \
+    TraceLoggingKeyword(keyword), \
+    __VA_ARGS__)
+
+// Macros to simplify basic logging.
+#define LogCritical(eventName, ...) /* Critical = level 1 */ \
+    DRIVER_TRACE(eventName, TRACE_LEVEL_CRITICAL, DRIVER_KEYWORD_LOG, __VA_ARGS__)
+#define LogError(eventName, ...)    /* Error = level 2 */ \
+    DRIVER_TRACE(eventName, TRACE_LEVEL_ERROR, DRIVER_KEYWORD_LOG, __VA_ARGS__)
+#define LogWarning(eventName, ...)  /* Warning = level 3 */ \
+    DRIVER_TRACE(eventName, TRACE_LEVEL_WARNING, DRIVER_KEYWORD_LOG, __VA_ARGS__)
+#define LogInfo(eventName, ...)     /* Info = level 4 */  \
+    DRIVER_TRACE(eventName, TRACE_LEVEL_INFORMATION, DRIVER_KEYWORD_LOG, __VA_ARGS__)
+#define LogVerbose(eventName, ...)  /* Verbose = level 5 */ \
+    DRIVER_TRACE(eventName, TRACE_LEVEL_VERBOSE, DRIVER_KEYWORD_LOG, __VA_ARGS__)
+
+// Some events are useful during driver initialization and become overly verbose
+// afterwards. Such events can be logged as: LogVerboseInfo(...), which only
+// logs the first 100 VerboseInfo events.
+#define LogVerboseInfo(eventName, ...) \
+    if (!DriverShouldLogVerboseInfo()) \
+    {} \
+    else \
+    LogInfo(eventName, __VA_ARGS__)


### PR DESCRIPTION
sdport-based miniport driver for RPI4's emmc2 controller.

- Supports UHS-DDR50
- Supports DMA (via bounce buffer)

Intended to help with issue #20