### PR TITLE
brcme88c - support sdhost stepping C0 (RPi400)

### DIFF
--- a/drivers/sd/bcm2711/brcme88c/SlotExtension.h
+++ b/drivers/sd/bcm2711/brcme88c/SlotExtension.h
@@ -205,6 +205,7 @@ private:
     MDL* m_pDmaDescriptorMdl;
     UINT32 m_iDmaEndDescriptor; // The index of the descriptor where End == true.
     SDPORT_TRANSFER_DIRECTION m_dmaInProgress;
+    UINT32 m_dmaTranslation; // 0xC0000000 on old chips, 0x0 on new chips.
     Magic m_magic;
     bool m_crashDumpMode;
     bool m_regulatorVoltage1_8;


### PR DESCRIPTION
C0 revision of the sdhost controller does not have a DMA offset, so
detect revision and use the offset appropriate for the revision.