### PR TITLE
bcmemmc2 - use OverrrideFlags

### DIFF
--- a/drivers/sd/bcm2711/bcmemmc2/bcmemmc2.inx
+++ b/drivers/sd/bcm2711/bcmemmc2/bcmemmc2.inx
@@ -72,13 +72,6 @@ HKR,Parameters,SdAppCmdFlags,1, 06,01, 0D,01, 16,01, 17,01, 33,01, \
                                 12,01, 19,01, 1A,01, 26,01, 2B,01, \
                                 2C,01, 2D,01, 2E,01, 2F,01, 30,01, 31,01, 33,01
 
-;
-; these modes require 1.8 V signaling, so are not yet supported
-;
-HKR, Parameters, DisableUhsSupport   ,%REG_DWORD%, 1
-HKR, Parameters, DisableHS200Support ,%REG_DWORD%, 1
-HKR, Parameters, DisableHS400Support ,%REG_DWORD%, 1
-
 ; //////////////////////////////////////////////////////////
 ;
 ; Controller Specific Sections
@@ -96,7 +89,14 @@ HKR, Parameters, DisableHS400Support ,%REG_DWORD%, 1
 ;       3 -> ADMA mode
 ;       4 -> System DMA (Texas Instruments OMAP specific)
 ;
+; TODO: Needed only for B0 stepping. C0 and later should enable DMA.
 HKR,, DmaMethod ,%REG_DWORD%, 1 ; PIO mode for now (we'll need a filter driver similar to rpiuxflt for DMA)
+;
+; OverrideFlags:
+;       0x10000000 -> Disable UHS (UHS requires voltage regulator control)
+;       0x00008000 -> Disable 8BIT (capabilities wrongly claim 8-bit bus support)
+;
+HKR,, OverrideFlags, %REG_DWORD%, 0x10008000
 
 [SDHostEMMC2]
 AddReg    = SDBUSReg


### PR DESCRIPTION
We're currently using service parameters (which apply at the driver
level) to disable UHS. We should instead be using OverrideFlags (which
apply at the device level).

- Disabled UHS since sdbus.sys can't configure the voltage regulator.
- Disabled 8BIT because SDHOST capabilities incorrectly claim 8-bit support.

For future consideration, sdbus.sys DMA works fine on RPi400. If we
could get a distinct hardware ID for the new chip (e.g. a REV), we could
enable DMA support on RPi400. In fact, on RPi400, sdbus.sys seems to work
ok with no overrides, so it would be reasonable to declare the C0
revision as compatible with standard sdhost.