### PR TITLE
Fix build errors after the VS 16.10 update

### DIFF
--- a/drivers/mailbox/bcm2836/rpiq.vcxproj
+++ b/drivers/mailbox/bcm2836/rpiq.vcxproj
@@ -76,6 +76,7 @@
       <WppAddAlternateNameToMessageGUID>rpiq</WppAddAlternateNameToMessageGUID>
       <WppPreprocessorDefinitions>ENABLE_WPP_RECORDER=1;WPP_EMIT_FUNC_NAME</WppPreprocessorDefinitions>
       <WppScanConfigurationData>trace.h</WppScanConfigurationData>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);_NO_CRT_STDIO_INLINE;</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -84,6 +85,7 @@
       <WppAddAlternateNameToMessageGUID>rpiq</WppAddAlternateNameToMessageGUID>
       <WppPreprocessorDefinitions>ENABLE_WPP_RECORDER=1;WPP_EMIT_FUNC_NAME</WppPreprocessorDefinitions>
       <WppScanConfigurationData>trace.h</WppScanConfigurationData>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);_NO_CRT_STDIO_INLINE;</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
@@ -92,6 +94,7 @@
       <WppAddAlternateNameToMessageGUID>rpiq</WppAddAlternateNameToMessageGUID>
       <WppPreprocessorDefinitions>ENABLE_WPP_RECORDER=1;WPP_EMIT_FUNC_NAME</WppPreprocessorDefinitions>
       <WppScanConfigurationData>trace.h</WppScanConfigurationData>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);_NO_CRT_STDIO_INLINE;</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
@@ -100,6 +103,7 @@
       <WppAddAlternateNameToMessageGUID>rpiq</WppAddAlternateNameToMessageGUID>
       <WppPreprocessorDefinitions>ENABLE_WPP_RECORDER=1;WPP_EMIT_FUNC_NAME</WppPreprocessorDefinitions>
       <WppScanConfigurationData>trace.h</WppScanConfigurationData>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);_NO_CRT_STDIO_INLINE;</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <!-- Set default environment variables, e.g. for stampinf -->

--- a/drivers/misc/userland/interface/vcos/generic/vcos_win32_kern_generic.vcxproj
+++ b/drivers/misc/userland/interface/vcos/generic/vcos_win32_kern_generic.vcxproj
@@ -74,6 +74,10 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalOptions>/source-charset:.1252 %(AdditionalOptions)</AdditionalOptions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">

--- a/drivers/misc/userland/interface/vcos/win32/vcos_platform.h
+++ b/drivers/misc/userland/interface/vcos/win32/vcos_platform.h
@@ -135,12 +135,6 @@ extern "C" {
 
 RTL_RUN_ONCE_INIT_FN  InitHandleFunction;
 
-struct timespec
-{
-    time_t tv_sec;  // Seconds - >= 0
-    long   tv_nsec; // Nanoseconds - [0, 999999999]
-};
-
 #else
 
 BOOL CALLBACK InitHandleFunction (PINIT_ONCE InitOnce,

--- a/drivers/misc/userland/interface/vcos/win32/vcos_win32_kern.vcxproj
+++ b/drivers/misc/userland/interface/vcos/win32/vcos_win32_kern.vcxproj
@@ -82,24 +82,36 @@
       <AdditionalDependencies>vcos_win32_kern_generic.lib;%(AdditionalDependencies);$(ConvertedTargetLibs);$(ConvertedUMLIBS)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutputPath); $(OBJ_PATH)\..\generic\$(O)\</AdditionalLibraryDirectories>
     </Link>
+    <ClCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;_NO_CRT_STDIO_INLINE</PreprocessorDefinitions>
+    </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
       <AdditionalDependencies>vcos_win32_kern_generic.lib;%(AdditionalDependencies);$(ConvertedTargetLibs);$(ConvertedUMLIBS)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutputPath); $(OBJ_PATH)\..\generic\$(O)\</AdditionalLibraryDirectories>
     </Link>
+    <ClCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;_NO_CRT_STDIO_INLINE</PreprocessorDefinitions>
+    </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <Link>
       <AdditionalDependencies>vcos_win32_kern_generic.lib;%(AdditionalDependencies);$(ConvertedTargetLibs);$(ConvertedUMLIBS)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutputPath); $(OBJ_PATH)\..\generic\$(O)\</AdditionalLibraryDirectories>
     </Link>
+    <ClCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;_NO_CRT_STDIO_INLINE</PreprocessorDefinitions>
+    </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <Link>
       <AdditionalDependencies>vcos_win32_kern_generic.lib;%(AdditionalDependencies);$(ConvertedTargetLibs);$(ConvertedUMLIBS)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutputPath); $(OBJ_PATH)\..\generic\$(O)\</AdditionalLibraryDirectories>
     </Link>
+    <ClCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;_NO_CRT_STDIO_INLINE</PreprocessorDefinitions>
+    </ClCompile>
   </ItemDefinitionGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />

--- a/drivers/uart/bcm2836/serPL011/SerPL011.vcxproj
+++ b/drivers/uart/bcm2836/serPL011/SerPL011.vcxproj
@@ -82,6 +82,7 @@
       <WppPreprocessorDefinitions>ENABLE_WPP_RECORDER=1;WPP_EMIT_FUNC_NAME</WppPreprocessorDefinitions>
       <WppScanConfigurationData>PL011logging.h</WppScanConfigurationData>
       <EnablePREfast>false</EnablePREfast>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);_NO_CRT_STDIO_INLINE</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
@@ -93,6 +94,7 @@
       <WppPreprocessorDefinitions>ENABLE_WPP_RECORDER=1;WPP_EMIT_FUNC_NAME</WppPreprocessorDefinitions>
       <WppScanConfigurationData>PL011logging.h</WppScanConfigurationData>
       <EnablePREfast>false</EnablePREfast>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);_NO_CRT_STDIO_INLINE</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
@@ -104,6 +106,7 @@
       <WppPreprocessorDefinitions>ENABLE_WPP_RECORDER=1;WPP_EMIT_FUNC_NAME</WppPreprocessorDefinitions>
       <WppScanConfigurationData>PL011logging.h</WppScanConfigurationData>
       <EnablePREfast>false</EnablePREfast>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);_NO_CRT_STDIO_INLINE</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -115,6 +118,7 @@
       <WppPreprocessorDefinitions>ENABLE_WPP_RECORDER=1;WPP_EMIT_FUNC_NAME</WppPreprocessorDefinitions>
       <WppScanConfigurationData>PL011logging.h</WppScanConfigurationData>
       <EnablePREfast>false</EnablePREfast>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);_NO_CRT_STDIO_INLINE</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <!-- Set default environment variables, e.g. for stampinf -->


### PR DESCRIPTION
* Inline functions from stdio cause link-time errors.
  Microsoft seems to be aware of this, as per: https://stackoverflow.com/a/67745800

* vcos_win32_kern / vcos_win32_kern_generic: strncpy is deprecated and
  the warnings are treated as errors.

* vcos_win32_kern (vcos_platform.h): timespec is already declared in time.h